### PR TITLE
Dataclass help message

### DIFF
--- a/nemo_skills/evaluation/evaluate_results.py
+++ b/nemo_skills/evaluation/evaluate_results.py
@@ -13,15 +13,14 @@
 # limitations under the License.
 
 import logging
+import sys
 from dataclasses import dataclass, field
-from pathlib import Path
-from typing import Optional
 
 import hydra
 from omegaconf import MISSING, OmegaConf
 
 from nemo_skills.code_execution.sandbox import get_sandbox
-from nemo_skills.utils import setup_logging
+from nemo_skills.utils import print_fields_docstring, setup_logging
 
 LOG = logging.getLogger(__file__)
 
@@ -71,5 +70,8 @@ def evaluate_results(cfg: EvaluateResultsConfig):
 
 
 if __name__ == "__main__":
-    setup_logging()
-    evaluate_results()
+    if '--help' in sys.argv:
+        print_fields_docstring(EvaluateResultsConfig)
+    else:
+        setup_logging()
+        evaluate_results()

--- a/nemo_skills/evaluation/evaluate_results.py
+++ b/nemo_skills/evaluation/evaluate_results.py
@@ -20,7 +20,7 @@ import hydra
 from omegaconf import MISSING, OmegaConf
 
 from nemo_skills.code_execution.sandbox import get_sandbox
-from nemo_skills.utils import print_fields_docstring, setup_logging
+from nemo_skills.utils import get_fields_docstring, setup_logging
 
 LOG = logging.getLogger(__file__)
 
@@ -71,7 +71,8 @@ def evaluate_results(cfg: EvaluateResultsConfig):
 
 if __name__ == "__main__":
     if '--help' in sys.argv:
-        print_fields_docstring(EvaluateResultsConfig)
+        help_msg = get_fields_docstring(EvaluateResultsConfig)
+        print(help_msg)
     else:
         setup_logging()
         evaluate_results()

--- a/nemo_skills/evaluation/evaluate_results.py
+++ b/nemo_skills/evaluation/evaluate_results.py
@@ -20,7 +20,7 @@ import hydra
 from omegaconf import MISSING, OmegaConf
 
 from nemo_skills.code_execution.sandbox import get_sandbox
-from nemo_skills.utils import get_fields_docstring, setup_logging
+from nemo_skills.utils import get_help_message, setup_logging
 
 LOG = logging.getLogger(__file__)
 
@@ -71,7 +71,7 @@ def evaluate_results(cfg: EvaluateResultsConfig):
 
 if __name__ == "__main__":
     if '--help' in sys.argv:
-        help_msg = get_fields_docstring(EvaluateResultsConfig)
+        help_msg = get_help_message(EvaluateResultsConfig)
         print(help_msg)
     else:
         setup_logging()

--- a/nemo_skills/finetuning/prepare_masked_data.py
+++ b/nemo_skills/finetuning/prepare_masked_data.py
@@ -24,7 +24,7 @@ from omegaconf import MISSING, OmegaConf
 
 sys.path.append(str(Path(__file__).absolute().parents[2]))
 
-from nemo_skills.utils import setup_logging, unroll_files
+from nemo_skills.utils import get_help_message, setup_logging, unroll_files
 
 LOG = logging.getLogger(__file__)
 
@@ -157,5 +157,9 @@ def prepare_masked_data(cfg: PrepareMaskedDataConfig):
 
 
 if __name__ == '__main__':
-    setup_logging()
-    prepare_masked_data()
+    if '--help' in sys.argv:
+        help_msg = get_help_message(PrepareMaskedDataConfig)
+        print(help_msg)
+    else:
+        setup_logging()
+        prepare_masked_data()

--- a/nemo_skills/finetuning/prepare_sft_data.py
+++ b/nemo_skills/finetuning/prepare_sft_data.py
@@ -34,7 +34,7 @@ sys.path.append(str(Path(__file__).absolute().parents[2]))
 
 from nemo_skills.finetuning.filtering_utils import downsample_data, process_bad_solutions
 from nemo_skills.inference.prompt.utils import PromptConfig, get_prompt
-from nemo_skills.utils import get_fields_docstring, setup_logging, unroll_files
+from nemo_skills.utils import get_help_message, setup_logging, unroll_files
 
 LOG = logging.getLogger(__file__)
 
@@ -208,8 +208,8 @@ def prepare_sft_data(cfg: PrepareSFTDataConfig):
 
 if __name__ == "__main__":
     if '--help' in sys.argv:
-        help_msg = get_fields_docstring(PrepareSFTDataConfig)
-        # print(help_msg)
+        help_msg = get_help_message(PrepareSFTDataConfig)
+        print(help_msg)
     else:
         setup_logging()
         prepare_sft_data()

--- a/nemo_skills/finetuning/prepare_sft_data.py
+++ b/nemo_skills/finetuning/prepare_sft_data.py
@@ -21,6 +21,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from itertools import zip_longest
 from pathlib import Path
+from pydoc import doc
 from typing import Dict, List, Optional
 
 import hydra
@@ -33,7 +34,7 @@ sys.path.append(str(Path(__file__).absolute().parents[2]))
 
 from nemo_skills.finetuning.filtering_utils import downsample_data, process_bad_solutions
 from nemo_skills.inference.prompt.utils import PromptConfig, get_prompt
-from nemo_skills.utils import print_fields_docstring, setup_logging, unroll_files
+from nemo_skills.utils import get_fields_docstring, setup_logging, unroll_files
 
 LOG = logging.getLogger(__file__)
 
@@ -207,7 +208,8 @@ def prepare_sft_data(cfg: PrepareSFTDataConfig):
 
 if __name__ == "__main__":
     if '--help' in sys.argv:
-        print_fields_docstring(PrepareSFTDataConfig)
+        help_msg = get_fields_docstring(PrepareSFTDataConfig)
+        # print(help_msg)
     else:
         setup_logging()
         prepare_sft_data()

--- a/nemo_skills/finetuning/prepare_sft_data.py
+++ b/nemo_skills/finetuning/prepare_sft_data.py
@@ -33,7 +33,7 @@ sys.path.append(str(Path(__file__).absolute().parents[2]))
 
 from nemo_skills.finetuning.filtering_utils import downsample_data, process_bad_solutions
 from nemo_skills.inference.prompt.utils import PromptConfig, get_prompt
-from nemo_skills.utils import setup_logging, unroll_files
+from nemo_skills.utils import print_fields_docstring, setup_logging, unroll_files
 
 LOG = logging.getLogger(__file__)
 
@@ -206,5 +206,8 @@ def prepare_sft_data(cfg: PrepareSFTDataConfig):
 
 
 if __name__ == "__main__":
-    setup_logging()
-    prepare_sft_data()
+    if '--help' in sys.argv:
+        print_fields_docstring(PrepareSFTDataConfig)
+    else:
+        setup_logging()
+        prepare_sft_data()

--- a/nemo_skills/finetuning/prepare_sft_data.py
+++ b/nemo_skills/finetuning/prepare_sft_data.py
@@ -21,8 +21,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from itertools import zip_longest
 from pathlib import Path
-from pydoc import doc
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import hydra
 import numpy as np
@@ -64,7 +63,7 @@ class PrepareSFTDataConfig:
     preprocessed_dataset_files: Optional[str] = None  # can specify datasets from HF instead of prediction_jsonl_files
     output_path: str = MISSING
     # can provide additional metadata to store (e.g. dataset or generation_type)
-    metadata: Dict = field(default_factory=dict)
+    metadata: Dict[Any, Any] = field(default_factory=dict)
     skip_first: int = 0  # useful for skipping validation set from train_full generation (it's always first)
     add_correct: bool = True  # can set to False if only want to export incorrect solutions
     add_incorrect: bool = False  # if True, saves only incorrect solutions instead of correct

--- a/nemo_skills/inference/generate_solutions.py
+++ b/nemo_skills/inference/generate_solutions.py
@@ -14,6 +14,7 @@
 
 import json
 import logging
+import sys
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Optional
@@ -25,7 +26,7 @@ from tqdm import tqdm
 from nemo_skills.code_execution.sandbox import get_sandbox
 from nemo_skills.inference.prompt.utils import PromptConfig, get_prompt
 from nemo_skills.inference.server.model import get_model
-from nemo_skills.utils import setup_logging
+from nemo_skills.utils import print_fields_docstring, setup_logging
 
 LOG = logging.getLogger(__file__)
 
@@ -137,5 +138,8 @@ def generate_solutions(cfg: GenerateSolutionsConfig):
 
 
 if __name__ == "__main__":
-    setup_logging()
-    generate_solutions()
+    if '--help' in sys.argv:
+        print_fields_docstring(GenerateSolutionsConfig)
+    else:
+        setup_logging()
+        generate_solutions()

--- a/nemo_skills/inference/generate_solutions.py
+++ b/nemo_skills/inference/generate_solutions.py
@@ -26,7 +26,7 @@ from tqdm import tqdm
 from nemo_skills.code_execution.sandbox import get_sandbox
 from nemo_skills.inference.prompt.utils import PromptConfig, get_prompt
 from nemo_skills.inference.server.model import get_model
-from nemo_skills.utils import get_fields_docstring, setup_logging
+from nemo_skills.utils import get_help_message, setup_logging
 
 LOG = logging.getLogger(__file__)
 
@@ -139,7 +139,7 @@ def generate_solutions(cfg: GenerateSolutionsConfig):
 
 if __name__ == "__main__":
     if '--help' in sys.argv:
-        help_msg = get_fields_docstring(GenerateSolutionsConfig)
+        help_msg = get_help_message(GenerateSolutionsConfig)
         print(help_msg)
     else:
         setup_logging()

--- a/nemo_skills/inference/generate_solutions.py
+++ b/nemo_skills/inference/generate_solutions.py
@@ -26,7 +26,7 @@ from tqdm import tqdm
 from nemo_skills.code_execution.sandbox import get_sandbox
 from nemo_skills.inference.prompt.utils import PromptConfig, get_prompt
 from nemo_skills.inference.server.model import get_model
-from nemo_skills.utils import print_fields_docstring, setup_logging
+from nemo_skills.utils import get_fields_docstring, setup_logging
 
 LOG = logging.getLogger(__file__)
 
@@ -139,7 +139,8 @@ def generate_solutions(cfg: GenerateSolutionsConfig):
 
 if __name__ == "__main__":
     if '--help' in sys.argv:
-        print_fields_docstring(GenerateSolutionsConfig)
+        help_msg = get_fields_docstring(GenerateSolutionsConfig)
+        print(help_msg)
     else:
         setup_logging()
         generate_solutions()

--- a/nemo_skills/utils.py
+++ b/nemo_skills/utils.py
@@ -95,7 +95,7 @@ def extract_comments_above_fields(dataclass_obj, prefix: str = '', level: int = 
 
     for line in source_lines:
         # skip unfinished multiline comments
-        if line.count("'") % 2 or line.count('"') % 2:
+        if line.count("'") == 3 or line.count('"') == 3:
             continue
         line_comment = extract_comments(line)
         if line_comment:
@@ -142,3 +142,15 @@ def get_fields_docstring(dataclass_obj):
     commented_fields = extract_comments_above_fields(dataclass_obj)
     docstring = [content for content in commented_fields.values()]
     return '\n\n'.join(docstring)
+
+
+def get_help_message(dataclass_obj):
+    heading = """
+This script uses Hydra for dynamic configuration management.
+You can apply Hydra's command-line syntax for overriding configuration values directly.
+Below are the available configuration options and their default values:
+    """.strip()
+
+    docstring = get_fields_docstring(dataclass_obj)
+
+    return f"{heading}\n\n{'-' * 75}\n\n{docstring}"

--- a/nemo_skills/utils.py
+++ b/nemo_skills/utils.py
@@ -17,7 +17,7 @@ import inspect
 import logging
 import sys
 import typing
-from dataclasses import fields, is_dataclass, MISSING
+from dataclasses import MISSING, fields, is_dataclass
 
 
 def unroll_files(prediction_jsonl_files):
@@ -73,8 +73,9 @@ def extract_comments_above_fields(dataclass_obj, prefix: str = '', level: int = 
         field.name: {
             'type': field.type,
             'default': field.default if field.default != MISSING else None,
-            'default_factory': field.default_factory if field.default_factory != MISSING else None
-        } for field in fields(dataclass_obj)
+            'default_factory': field.default_factory if field.default_factory != MISSING else None,
+        }
+        for field in fields(dataclass_obj)
     }
     comments, comment_cache = {}, []
 
@@ -95,7 +96,7 @@ def extract_comments_above_fields(dataclass_obj, prefix: str = '', level: int = 
         default_factory = field_info['default_factory']
         default_factory_str = f', Default Factory: {default_factory.__name__}' if default_factory else ''
         default_str = f', Default: {default}' if not default_factory else default_factory_str
-        
+
         comment = '. '.join(comment_cache)
         field_detail = f"{'  ' * level}{prefix + field_name}: {comment}\n{'  ' * level}Type: {field_type}{default_str}"
         comments[field_name] = field_detail
@@ -103,7 +104,9 @@ def extract_comments_above_fields(dataclass_obj, prefix: str = '', level: int = 
 
         # Recursively extract nested dataclasses
         if is_dataclass(field_info['type']):
-            nested_comments = extract_comments_above_fields(field_info['type'], prefix=prefix + field_name + '.', level=level + 1)
+            nested_comments = extract_comments_above_fields(
+                field_info['type'], prefix=prefix + field_name + '.', level=level + 1
+            )
             for k, v in nested_comments.items():
                 comments[f"{prefix}{field_name}.{k}"] = v
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ dependencies = [
   'tqdm',
   'pyyaml',
   'numpy',
+  'requests',
+  'sympy',
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
This PR allows to show customized help message for the dataclasses defined in `.py` files.

This is done via comment and argument parsing from the dataclass code.

Usage example:
`python3 nemo_skills/finetuning/prepare_sft_data.py --help`

```
prediction_jsonl_files: can specify multiple patters separated by space
Type: Optional[str], Default: None

preprocessed_dataset_files: can specify datasets from HF instead of prediction_jsonl_files
Type: Optional[str], Default: None

output_path: 
Type: str, Default: ???

metadata: can provide additional metadata to store (e.g. dataset or generation_type)
Type: dict[], Default Factory: dict

skip_first: useful for skipping validation set from train_full generation (it's always first)
Type: int, Default: 0

add_correct: can set to False if only want to export incorrect solutions
Type: bool, Default: True

add_incorrect: if True, saves only incorrect solutions instead of correct
Type: bool, Default: False

downsampling_method: random or fair
Type: Optional[str], Default: None

num_output_samples: 
Type: int, Default: -1

prompt: 
Type: PromptConfig, Default Factory: get_default_prompt_config

  prompt.delimiter: 
  Type: str, Default: ???

  prompt.prefix: 
  Type: str, Default: ???

  prompt.template: 
  Type: str, Default: ???

  prompt.context_type: 
  Type: str, Default: empty

  prompt.examples_type: 
  Type: Optional[str], Default: None

  prompt.num_few_shots: 
  Type: int, Default: 5

filters: 
Type: list[str], Default Factory: <lambda>

text_filter_type: 
Type: Optional[str], Default: None

trim_solutions: 
Type: bool, Default: False

```