### PR TITLE
Switch trtllm slurm scripts to use mpirun directly for better stability

### DIFF
--- a/pipeline/launcher.py
+++ b/pipeline/launcher.py
@@ -51,7 +51,7 @@ def get_server_command(server_type, num_gpus):
             num_tasks = 1
     else:
         server_start_cmd = (
-            f"(mpirun -np {num_gpus} python /code/nemo_skills/inference/server/serve_trt.py "
+            f"(mpirun -np {num_gpus} --allow-run-as-root --oversubscribe python /code/nemo_skills/inference/server/serve_trt.py "
             "--model_path /model > /tmp/server_logs.txt &)"
         )
         num_tasks = 1  # we launch via mpirun directly

--- a/pipeline/launcher.py
+++ b/pipeline/launcher.py
@@ -40,16 +40,23 @@ def fill_env_vars(format_dict, env_vars):
 
 
 def get_server_command(server_type, num_gpus):
+    num_tasks = num_gpus
     if server_type == 'nemo':
         server_start_cmd = (
             f"(python /code/nemo_skills/inference/server/serve_nemo.py gpt_model_file=/model trainer.devices={num_gpus} "
             f"tensor_model_parallel_size={num_gpus} > /tmp/server_logs.txt &)"
         )
+        # somehow on slurm nemo needs multiple tasks, but locally only 1
+        if CLUSTER_CONFIG["cluster"] == "local":
+            num_tasks = 1
     else:
         server_start_cmd = (
-            "(python /code/nemo_skills/inference/server/serve_trt.py --model_path /model > /tmp/server_logs.txt &)"
+            f"(mpirun -np {num_gpus} python /code/nemo_skills/inference/server/serve_trt.py "
+            "--model_path /model > /tmp/server_logs.txt &)"
         )
-    return server_start_cmd
+        num_tasks = 1  # we launch via mpirun directly
+
+    return server_start_cmd, num_tasks
 
 
 SLURM_HEADER = """

--- a/pipeline/run_eval.py
+++ b/pipeline/run_eval.py
@@ -101,7 +101,7 @@ if __name__ == "__main__":
     args.model_path = Path(args.model_path).absolute()
     args.output_dir = Path(args.output_dir).absolute()
 
-    server_start_cmd = get_server_command(args.server_type, args.num_gpus)
+    server_start_cmd, num_tasks = get_server_command(args.server_type, args.num_gpus)
 
     format_dict = {
         "model_path": args.model_path,
@@ -130,11 +130,6 @@ if __name__ == "__main__":
 
     # splitting eval cmds equally across num_nodes nodes
     eval_cmds = [" ".join(eval_cmds[i :: args.num_nodes]) for i in range(args.num_nodes)]
-
-    num_tasks = format_dict["num_gpus"]
-    # somehow on slurm nemo needs multiple tasks, but locally only 1
-    if args.server_type == "nemo" and CLUSTER_CONFIG["cluster"] == "local":
-        num_tasks = 1
 
     for idx, eval_cmd in enumerate(eval_cmds):
         extra_sbatch_args = ["--parsable", f"--output={args.output_dir}/slurm_logs_eval{idx}.log"]

--- a/pipeline/start_server.py
+++ b/pipeline/start_server.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
 
     args.model_path = Path(args.model_path).absolute()
 
-    server_start_cmd = get_server_command(args.server_type, args.num_gpus)
+    server_start_cmd, num_tasks = get_server_command(args.server_type, args.num_gpus)
 
     format_dict = {
         "model_path": args.model_path,
@@ -74,11 +74,6 @@ if __name__ == "__main__":
         "server_type": args.server_type,
     }
     fill_env_vars(format_dict, ["NEMO_SKILLS_CODE"])
-
-    num_tasks = format_dict["num_gpus"]
-    # somehow on slurm nemo needs multiple tasks, but locally only 1
-    if args.server_type == "nemo" and CLUSTER_CONFIG["cluster"] == "local":
-        num_tasks = 1
 
     job_id = launch_job(
         cmd=SLURM_CMD.format(**format_dict),


### PR DESCRIPTION
Need this to avoid errors on some slurm configurations.