### PR TITLE
Improvements to automatic cmd help + docs for generate solutions and run evals

### DIFF
--- a/nemo_skills/code_execution/sandbox.py
+++ b/nemo_skills/code_execution/sandbox.py
@@ -22,7 +22,7 @@ from concurrent.futures import ThreadPoolExecutor
 from itertools import zip_longest
 from typing import Dict, List, Optional, Tuple
 
-from nemo_skills.utils import unroll_files
+from nemo_skills.utils import unroll_files, python_doc_to_cmd_help
 
 LOG = logging.getLogger(__file__)
 
@@ -170,6 +170,19 @@ class Sandbox(abc.ABC):
 
 
 class LocalSandbox(Sandbox):
+    """Locally hosted sandbox.
+
+    Args:
+        host: Optional[str] = '127.0.0.1' - Host of the sandbox server.
+            Can also be specified through NEMO_SKILLS_SANDBOX_HOST env var.
+        port: Optional[str] = '5000' - Port of the sandbox server.
+            Can also be specified through NEMO_SKILLS_SANDBOX_PORT env var.
+        ssh_server: Optional[str] = None - SSH server for tunneling requests.
+            Useful if server is running on slurm cluster to which there is an ssh access.
+            Can also be specified through SSH_SERVER env var.
+        ssh_key_path: Optional[str] = None - Path to the ssh key for tunneling.
+            Can also be specified through SSH_KEY_PATH env var.
+    """
     def __init__(
         self,
         host: str = os.getenv("NEMO_SKILLS_SANDBOX_HOST", "127.0.0.1"),
@@ -255,10 +268,19 @@ class LocalSandbox(Sandbox):
         return output
 
 
+sandboxes = {
+    'local': LocalSandbox,
+}
+
+
 def get_sandbox(sandbox_type, **kwargs):
-    if sandbox_type == "local":
-        return LocalSandbox(**kwargs)
-    elif sandbox_type == "aws":
-        raise NotImplementedError("Support for AWS sandbox is coming soon!")
-    else:
-        raise ValueError(f"Unsupported sandbox type: {sandbox_type}")
+    """A helper function to make it easier to set sandbox through cmd."""
+    sandbox_class = sandboxes[sandbox_type.lower()]
+    return sandbox_class(**kwargs)
+
+
+def sandbox_params():
+    """Returns sandbox documentation (to include in cmd help)."""
+    prefix = f'\n        sandbox_type: str = MISSING - Choices: {list(sandboxes.keys())}'
+    # only exposing docs for local sandbox for now. Need to change when we support other types
+    return python_doc_to_cmd_help(LocalSandbox, docs_prefix=prefix, arg_prefix="sandbox.")

--- a/nemo_skills/code_execution/sandbox.py
+++ b/nemo_skills/code_execution/sandbox.py
@@ -22,7 +22,7 @@ from concurrent.futures import ThreadPoolExecutor
 from itertools import zip_longest
 from typing import Dict, List, Optional, Tuple
 
-from nemo_skills.utils import unroll_files, python_doc_to_cmd_help
+from nemo_skills.utils import python_doc_to_cmd_help, unroll_files
 
 LOG = logging.getLogger(__file__)
 
@@ -183,6 +183,7 @@ class LocalSandbox(Sandbox):
         ssh_key_path: Optional[str] = None - Path to the ssh key for tunneling.
             Can also be specified through SSH_KEY_PATH env var.
     """
+
     def __init__(
         self,
         host: str = os.getenv("NEMO_SKILLS_SANDBOX_HOST", "127.0.0.1"),

--- a/nemo_skills/evaluation/evaluate_results.py
+++ b/nemo_skills/evaluation/evaluate_results.py
@@ -13,15 +13,14 @@
 # limitations under the License.
 
 import logging
+import sys
 from dataclasses import dataclass, field
-from pathlib import Path
-from typing import Optional
 
 import hydra
 from omegaconf import MISSING, OmegaConf
 
 from nemo_skills.code_execution.sandbox import get_sandbox
-from nemo_skills.utils import setup_logging
+from nemo_skills.utils import get_help_message, setup_logging
 
 LOG = logging.getLogger(__file__)
 
@@ -71,5 +70,9 @@ def evaluate_results(cfg: EvaluateResultsConfig):
 
 
 if __name__ == "__main__":
-    setup_logging()
-    evaluate_results()
+    if '--help' in sys.argv:
+        help_msg = get_help_message(EvaluateResultsConfig)
+        print(help_msg)
+    else:
+        setup_logging()
+        evaluate_results()

--- a/nemo_skills/evaluation/evaluate_results.py
+++ b/nemo_skills/evaluation/evaluate_results.py
@@ -70,7 +70,7 @@ def evaluate_results(cfg: EvaluateResultsConfig):
 
 
 if __name__ == "__main__":
-    if '--help' in sys.argv:
+    if '--help' in sys.argv or '-h' in sys.argv:
         help_msg = get_help_message(EvaluateResultsConfig)
         print(help_msg)
     else:

--- a/nemo_skills/finetuning/prepare_masked_data.py
+++ b/nemo_skills/finetuning/prepare_masked_data.py
@@ -24,7 +24,7 @@ from omegaconf import MISSING, OmegaConf
 
 sys.path.append(str(Path(__file__).absolute().parents[2]))
 
-from nemo_skills.utils import setup_logging, unroll_files
+from nemo_skills.utils import get_help_message, setup_logging, unroll_files
 
 LOG = logging.getLogger(__file__)
 
@@ -157,5 +157,9 @@ def prepare_masked_data(cfg: PrepareMaskedDataConfig):
 
 
 if __name__ == '__main__':
-    setup_logging()
-    prepare_masked_data()
+    if '--help' in sys.argv:
+        help_msg = get_help_message(PrepareMaskedDataConfig)
+        print(help_msg)
+    else:
+        setup_logging()
+        prepare_masked_data()

--- a/nemo_skills/finetuning/prepare_masked_data.py
+++ b/nemo_skills/finetuning/prepare_masked_data.py
@@ -157,7 +157,7 @@ def prepare_masked_data(cfg: PrepareMaskedDataConfig):
 
 
 if __name__ == '__main__':
-    if '--help' in sys.argv:
+    if '--help' in sys.argv or '-h' in sys.argv:
         help_msg = get_help_message(PrepareMaskedDataConfig)
         print(help_msg)
     else:

--- a/nemo_skills/finetuning/prepare_sft_data.py
+++ b/nemo_skills/finetuning/prepare_sft_data.py
@@ -21,7 +21,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from itertools import zip_longest
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import hydra
 import numpy as np
@@ -33,7 +33,7 @@ sys.path.append(str(Path(__file__).absolute().parents[2]))
 
 from nemo_skills.finetuning.filtering_utils import downsample_data, process_bad_solutions
 from nemo_skills.inference.prompt.utils import PromptConfig, get_prompt
-from nemo_skills.utils import setup_logging, unroll_files
+from nemo_skills.utils import get_help_message, setup_logging, unroll_files
 
 LOG = logging.getLogger(__file__)
 
@@ -63,7 +63,7 @@ class PrepareSFTDataConfig:
     preprocessed_dataset_files: Optional[str] = None  # can specify datasets from HF instead of prediction_jsonl_files
     output_path: str = MISSING
     # can provide additional metadata to store (e.g. dataset or generation_type)
-    metadata: Dict = field(default_factory=dict)
+    metadata: Dict[Any, Any] = field(default_factory=dict)
     skip_first: int = 0  # useful for skipping validation set from train_full generation (it's always first)
     add_correct: bool = True  # can set to False if only want to export incorrect solutions
     add_incorrect: bool = False  # if True, saves only incorrect solutions instead of correct
@@ -206,5 +206,9 @@ def prepare_sft_data(cfg: PrepareSFTDataConfig):
 
 
 if __name__ == "__main__":
-    setup_logging()
-    prepare_sft_data()
+    if '--help' in sys.argv:
+        help_msg = get_help_message(PrepareSFTDataConfig)
+        print(help_msg)
+    else:
+        setup_logging()
+        prepare_sft_data()

--- a/nemo_skills/finetuning/prepare_sft_data.py
+++ b/nemo_skills/finetuning/prepare_sft_data.py
@@ -206,7 +206,7 @@ def prepare_sft_data(cfg: PrepareSFTDataConfig):
 
 
 if __name__ == "__main__":
-    if '--help' in sys.argv:
+    if '--help' in sys.argv or '-h' in sys.argv:
         help_msg = get_help_message(PrepareSFTDataConfig)
         print(help_msg)
     else:

--- a/nemo_skills/inference/generate_solutions.py
+++ b/nemo_skills/inference/generate_solutions.py
@@ -14,6 +14,7 @@
 
 import json
 import logging
+import sys
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Optional
@@ -25,7 +26,7 @@ from tqdm import tqdm
 from nemo_skills.code_execution.sandbox import get_sandbox
 from nemo_skills.inference.prompt.utils import PromptConfig, get_prompt
 from nemo_skills.inference.server.model import get_model
-from nemo_skills.utils import setup_logging
+from nemo_skills.utils import get_help_message, setup_logging
 
 LOG = logging.getLogger(__file__)
 
@@ -137,5 +138,9 @@ def generate_solutions(cfg: GenerateSolutionsConfig):
 
 
 if __name__ == "__main__":
-    setup_logging()
-    generate_solutions()
+    if '--help' in sys.argv:
+        help_msg = get_help_message(GenerateSolutionsConfig)
+        print(help_msg)
+    else:
+        setup_logging()
+        generate_solutions()

--- a/nemo_skills/inference/generate_solutions.py
+++ b/nemo_skills/inference/generate_solutions.py
@@ -23,7 +23,7 @@ import hydra
 from omegaconf import OmegaConf
 from tqdm import tqdm
 
-from nemo_skills.code_execution.sandbox import get_sandbox
+from nemo_skills.code_execution.sandbox import get_sandbox, sandbox_params
 from nemo_skills.inference.prompt.utils import PromptConfig, get_prompt, prompt_types, datasets
 from nemo_skills.inference.server.model import get_model, server_params
 from nemo_skills.utils import get_help_message, setup_logging
@@ -48,7 +48,8 @@ class GenerateSolutionsConfig:
     output_file: str  # where to save the generations
     # inference server configuration {server_params}
     server: dict
-    sandbox: dict  # will be directly passed to sandbox.get_sandbox function
+    # sandbox configuration {sandbox_params}
+    sandbox: dict
     # prompt configuration.
     # Available pre-configured prompts: {prompt_types}.
     prompt: PromptConfig = field(default_factory=PromptConfig)
@@ -144,12 +145,16 @@ def generate_solutions(cfg: GenerateSolutionsConfig):
 
 
 HELP_MESSAGE = get_help_message(
-    GenerateSolutionsConfig, datasets=datasets, server_params=server_params(), prompt_types=prompt_types
+    GenerateSolutionsConfig,
+    datasets=datasets,
+    prompt_types=prompt_types,
+    server_params=server_params(),
+    sandbox_params=sandbox_params(),
 )
 
 
 if __name__ == "__main__":
-    if '--help' in sys.argv:
+    if '--help' in sys.argv or '-h' in sys.argv:
         print(HELP_MESSAGE)
     else:
         setup_logging()

--- a/nemo_skills/inference/generate_solutions.py
+++ b/nemo_skills/inference/generate_solutions.py
@@ -24,8 +24,8 @@ from omegaconf import OmegaConf
 from tqdm import tqdm
 
 from nemo_skills.code_execution.sandbox import get_sandbox
-from nemo_skills.inference.prompt.utils import PromptConfig, get_prompt, datasets
-from nemo_skills.inference.server.model import get_model
+from nemo_skills.inference.prompt.utils import PromptConfig, get_prompt, prompt_types, datasets
+from nemo_skills.inference.server.model import get_model, server_params
 from nemo_skills.utils import get_help_message, setup_logging
 
 LOG = logging.getLogger(__file__)
@@ -46,12 +46,17 @@ class GenerateSolutionsConfig:
     """Top-level parameters for the script"""
 
     output_file: str  # where to save the generations
-    server: dict  # will be directly passed to model.get_client function
+    # inference server configuration {server_params}
+    server: dict
     sandbox: dict  # will be directly passed to sandbox.get_sandbox function
+    # prompt configuration.
+    # Available pre-configured prompts: {prompt_types}.
     prompt: PromptConfig = field(default_factory=PromptConfig)
     inference: InferenceConfig = field(default_factory=InferenceConfig)  # LLM call parameters
 
-    dataset: Optional[str] = None  # can specify one of the existing datasets. Choices: {datasets}
+    # can specify one of the existing datasets.
+    # Choices: {datasets}.
+    dataset: Optional[str] = None
     split_name: Optional[str] = None  # train, validation, test or train_full (train + validation)
     data_file: Optional[str] = None  # can directly specify a data file, if using a custom dataset
 
@@ -138,7 +143,9 @@ def generate_solutions(cfg: GenerateSolutionsConfig):
                 fout.write(json.dumps(output) + "\n")
 
 
-HELP_MESSAGE = get_help_message(GenerateSolutionsConfig, datasets=datasets)
+HELP_MESSAGE = get_help_message(
+    GenerateSolutionsConfig, datasets=datasets, server_params=server_params(), prompt_types=prompt_types
+)
 
 
 if __name__ == "__main__":

--- a/nemo_skills/inference/generate_solutions.py
+++ b/nemo_skills/inference/generate_solutions.py
@@ -24,17 +24,16 @@ from omegaconf import OmegaConf
 from tqdm import tqdm
 
 from nemo_skills.code_execution.sandbox import get_sandbox
-from nemo_skills.inference.prompt.utils import PromptConfig, get_prompt
+from nemo_skills.inference.prompt.utils import PromptConfig, get_prompt, datasets
 from nemo_skills.inference.server.model import get_model
 from nemo_skills.utils import get_help_message, setup_logging
 
 LOG = logging.getLogger(__file__)
 
 
-# TODO: help message?
 @dataclass
 class InferenceConfig:
-    temperature: float = 0.0  # greedy
+    temperature: float = 0.0  # temperature of 0 means greedy decoding
     top_k: int = 0
     top_p: float = 0.95
     random_seed: int = 0
@@ -46,19 +45,21 @@ class InferenceConfig:
 class GenerateSolutionsConfig:
     """Top-level parameters for the script"""
 
-    output_file: str
+    output_file: str  # where to save the generations
     server: dict  # will be directly passed to model.get_client function
     sandbox: dict  # will be directly passed to sandbox.get_sandbox function
     prompt: PromptConfig = field(default_factory=PromptConfig)
-    inference: InferenceConfig = field(default_factory=InferenceConfig)
+    inference: InferenceConfig = field(default_factory=InferenceConfig)  # LLM call parameters
 
-    dataset: Optional[str] = None
-    split_name: Optional[str] = None
-    data_file: Optional[str] = None
+    dataset: Optional[str] = None  # can specify one of the existing datasets. Choices: {datasets}
+    split_name: Optional[str] = None  # train, validation, test or train_full (train + validation)
+    data_file: Optional[str] = None  # can directly specify a data file, if using a custom dataset
 
     batch_size: int = 16
-    max_samples: int = -1
-    skip_filled: bool = False
+    max_samples: int = -1  # if > 0, will stop after generating this many samples. Useful for debugging
+    skip_filled: bool = False  # if True, will skip the generations that are already in the output file
+    # if > 0, will skip this many samples from the beginning of the data file.
+    # Useful if need to run multiple slurm jobs on the same data file
     offset: int = 0
 
     def __post_init__(self):
@@ -137,10 +138,12 @@ def generate_solutions(cfg: GenerateSolutionsConfig):
                 fout.write(json.dumps(output) + "\n")
 
 
+HELP_MESSAGE = get_help_message(GenerateSolutionsConfig, datasets=datasets)
+
+
 if __name__ == "__main__":
     if '--help' in sys.argv:
-        help_msg = get_help_message(GenerateSolutionsConfig)
-        print(help_msg)
+        print(HELP_MESSAGE)
     else:
         setup_logging()
         generate_solutions()

--- a/nemo_skills/inference/generate_solutions.py
+++ b/nemo_skills/inference/generate_solutions.py
@@ -33,7 +33,7 @@ LOG = logging.getLogger(__file__)
 
 @dataclass
 class InferenceConfig:
-    temperature: float = 0.0  # temperature of 0 means greedy decoding
+    temperature: float = 0.0  # Temperature of 0 means greedy decoding
     top_k: int = 0
     top_p: float = 0.95
     random_seed: int = 0
@@ -45,25 +45,25 @@ class InferenceConfig:
 class GenerateSolutionsConfig:
     """Top-level parameters for the script"""
 
-    output_file: str  # where to save the generations
-    # inference server configuration {server_params}
+    output_file: str  # Where to save the generations
+    # Inference server configuration {server_params}
     server: dict
-    # sandbox configuration {sandbox_params}
+    # Sandbox configuration {sandbox_params}
     sandbox: dict
-    # prompt configuration.
+    # Prompt configuration.
     # Available pre-configured prompts: {prompt_types}.
     prompt: PromptConfig = field(default_factory=PromptConfig)
     inference: InferenceConfig = field(default_factory=InferenceConfig)  # LLM call parameters
 
-    # can specify one of the existing datasets.
+    # Can specify one of the existing datasets.
     # Choices: {datasets}.
     dataset: Optional[str] = None
-    split_name: Optional[str] = None  # train, validation, test or train_full (train + validation)
-    data_file: Optional[str] = None  # can directly specify a data file, if using a custom dataset
+    split_name: Optional[str] = None  # Can be train, validation, test or train_full (train + validation)
+    data_file: Optional[str] = None  # Can directly specify a data file, if using a custom dataset
 
     batch_size: int = 16
-    max_samples: int = -1  # if > 0, will stop after generating this many samples. Useful for debugging
-    skip_filled: bool = False  # if True, will skip the generations that are already in the output file
+    max_samples: int = -1  # If > 0, will stop after generating this many samples. Useful for debugging
+    skip_filled: bool = False  # If True, will skip the generations that are already in the output file
     # if > 0, will skip this many samples from the beginning of the data file.
     # Useful if need to run multiple slurm jobs on the same data file
     offset: int = 0

--- a/nemo_skills/inference/server/model.py
+++ b/nemo_skills/inference/server/model.py
@@ -55,7 +55,7 @@ class BaseModel(abc.ABC):
             Only required if handle_code_execution is True.
         ssh_server: Optional[str] = None - SSH server for tunneling requests.
             Useful if server is running on slurm cluster to which there is an ssh access
-            Can also be specified through SSH_SERVER env var..
+            Can also be specified through SSH_SERVER env var.
         ssh_key_path: Optional[str] = None - Path to the ssh key for tunneling.
             Can also be specified through SSH_KEY_PATH env var.
         max_code_output_characters: Optional[int] = 1000 - Maximum number of characters for code execution output.

--- a/nemo_skills/utils.py
+++ b/nemo_skills/utils.py
@@ -13,8 +13,13 @@
 # limitations under the License.
 
 import glob
+import inspect
+import io
 import logging
 import sys
+import tokenize
+import typing
+from dataclasses import MISSING, fields, is_dataclass
 
 
 def unroll_files(prediction_jsonl_files):
@@ -36,3 +41,121 @@ def setup_logging(disable_hydra_logs: bool = True):
         sys.argv.extend(
             ["hydra.run.dir=.", "hydra.output_subdir=null", "hydra/job_logging=none", "hydra/hydra_logging=none"]
         )
+
+
+def extract_comments(code: str):
+    """Extract a list of comments from the given Python code."""
+    comments = []
+    tokens = tokenize.tokenize(io.BytesIO(code.encode()).readline)
+
+    for token, line, *_ in tokens:
+        if token is tokenize.COMMENT:
+            comments.append(line.lstrip('#').strip())
+
+    return comments
+
+
+def type_to_str(type_hint):
+    """Convert type hints to a more readable string."""
+    origin = typing.get_origin(type_hint)
+    args = typing.get_args(type_hint)
+
+    if hasattr(type_hint, '__name__'):
+        return type_hint.__name__.replace('NoneType', 'None')
+    elif origin is typing.Union:
+        if len(args) == 2 and type(None) in args:
+            return f'Optional[{type_to_str(args[0])}]'
+        else:
+            return ' or '.join(type_to_str(arg) for arg in args)
+    elif origin is typing.Callable:
+        if args[0] is Ellipsis:
+            args_str = '...'
+        else:
+            args_str = ', '.join(type_to_str(arg) for arg in args[:-1])
+        return f'Callable[[{args_str}], {type_to_str(args[-1])}]'
+    elif origin:
+        inner_types = ', '.join(type_to_str(arg) for arg in args)
+        origin_name = origin.__name__ if hasattr(origin, '__name__') else str(origin)
+        return f'{origin_name}[{inner_types}]'
+    else:
+        return str(type_hint).replace('typing.', '')
+
+
+def extract_comments_above_fields(dataclass_obj, prefix: str = '', level: int = 0):
+    source_lines = inspect.getsource(dataclass_obj).split('\n')
+    fields_info = {
+        field.name: {
+            'type': field.type,
+            'default': field.default if field.default != MISSING else None,
+            'default_factory': field.default_factory if field.default_factory != MISSING else None,
+        }
+        for field in fields(dataclass_obj)
+    }
+    comments, comment_cache = {}, []
+
+    for line in source_lines:
+        # skip unfinished multiline comments
+        if line.count("'") == 3 or line.count('"') == 3:
+            continue
+        line_comment = extract_comments(line)
+        if line_comment:
+            comment_cache.append(line_comment[0])
+        if ':' not in line:
+            continue
+
+        field_name = line.split(':')[0].strip()
+        if field_name not in fields_info:
+            continue
+
+        field_info = fields_info[field_name]
+        field_name = prefix + field_name
+        field_type = type_to_str(field_info['type'])
+        default = field_info['default']
+        default_factory = field_info['default_factory']
+        if default == '???':
+            default_str = ' = MISSING'
+        else:
+            default_str = f' = {default}'
+        if default_factory:
+            try:
+                default_factory = default_factory()
+                default_str = f' = {default_factory}'
+            except:
+                pass
+            if is_dataclass(default_factory):
+                default_str = f' = {field_type}()'
+
+        indent = '  ' * level
+        comment = f"\n{indent}".join(comment_cache)
+        comment = "- " + comment if comment else ""
+        field_detail = f"{indent}{field_name}: {field_type}{default_str} {comment}"
+        comments[field_name] = field_detail
+        comment_cache = []
+
+        # Recursively extract nested dataclasses
+        if is_dataclass(field_info['type']):
+            nested_comments = extract_comments_above_fields(
+                field_info['type'], prefix=field_name + '.', level=level + 1
+            )
+            for k, v in nested_comments.items():
+                comments[f"{field_name}.{k}"] = v
+
+    return comments
+
+
+def get_fields_docstring(dataclass_obj):
+    commented_fields = extract_comments_above_fields(dataclass_obj)
+    docstring = [content for content in commented_fields.values()]
+    return '\n'.join(docstring)
+
+
+def get_help_message(dataclass_obj):
+    heading = """
+This script uses Hydra (https://hydra.cc/) for dynamic configuration management.
+You can apply Hydra's command-line syntax for overriding configuration values directly.
+Below are the available configuration options and their default values:
+    """.strip()
+
+    docstring = get_fields_docstring(dataclass_obj)
+
+    return f"{heading}\n{'-' * 75}\n{docstring}"

--- a/nemo_skills/utils.py
+++ b/nemo_skills/utils.py
@@ -149,7 +149,7 @@ def get_fields_docstring(dataclass_obj):
     return '\n'.join(docstring)
 
 
-def get_help_message(dataclass_obj):
+def get_help_message(dataclass_obj, help_message=""):
     heading = """
 This script uses Hydra (https://hydra.cc/) for dynamic configuration management.
 You can apply Hydra's command-line syntax for overriding configuration values directly.
@@ -158,4 +158,8 @@ Below are the available configuration options and their default values:
 
     docstring = get_fields_docstring(dataclass_obj)
 
-    return f"{heading}\n{'-' * 75}\n{docstring}"
+    full_help = f"{heading}\n{'-' * 75}\n{docstring}"
+    if help_message:
+        full_help = f"{help_message}\n\n{full_help}"
+
+    return full_help

--- a/nemo_skills/utils.py
+++ b/nemo_skills/utils.py
@@ -158,6 +158,9 @@ Below are the available configuration options and their default values:
     """.strip()
 
     docstring = get_fields_docstring(dataclass_obj)
+    # to handle {} in docstring. Might need to add some other edge-case handling
+    # here, so that formatting does not complain
+    docstring = docstring.replace('{}', '{{}}')
     docstring = docstring.format(**kwargs)
 
     full_help = f"{heading}\n{'-' * 75}\n{docstring}"

--- a/nemo_skills/utils.py
+++ b/nemo_skills/utils.py
@@ -165,3 +165,24 @@ Below are the available configuration options and their default values:
         full_help = f"{help_message}\n\n{full_help}"
 
     return full_help
+
+
+def python_doc_to_cmd_help(doc_class, docs_prefix="", arg_prefix=""):
+    """Converts python doc to cmd help format.
+
+    Will color the args and change the format to match what we use in cmd help.
+    """
+    all_args = docs_prefix
+    all_args += doc_class.__doc__.split("Args:")[1].rstrip()
+    # \033[92m ... \033[0m - green in terminal
+    colored_args = ""
+    for line in all_args.split("\n"):
+        if "        " in line and " - " in line:
+            # add colors
+            line = line.replace("        ", "        \033[92m").replace(" - ", "\033[0m - ")
+            # fixing arg format
+            line = line.replace('        \033[92m', f'        \033[92m{arg_prefix}')
+        # fixing indent
+        line = line.replace("        ", "    ").replace("    ", "  ")
+        colored_args += line + '\n'
+    return colored_args[:-1]

--- a/nemo_skills/utils.py
+++ b/nemo_skills/utils.py
@@ -128,7 +128,7 @@ def extract_comments_above_fields(dataclass_obj, prefix: str = '', level: int = 
         indent = '  ' * level
         comment = f"\n{indent}".join(comment_cache)
         comment = "- " + comment if comment else ""
-        comment = comment.replace('\n', f'\n{indent}    ')
+        comment = comment.replace('\n', f'\n{indent}  ')
         field_detail = f"{indent}\033[92m{field_name}: {field_type}{default_str}\033[0m {comment}"
         comments[field_name] = field_detail
         comment_cache = []

--- a/nemo_skills/utils.py
+++ b/nemo_skills/utils.py
@@ -128,7 +128,8 @@ def extract_comments_above_fields(dataclass_obj, prefix: str = '', level: int = 
         indent = '  ' * level
         comment = f"\n{indent}".join(comment_cache)
         comment = "- " + comment if comment else ""
-        field_detail = f"{indent}{field_name}: {field_type}{default_str} {comment}"
+        comment = comment.replace('\n', f'\n{indent}    ')
+        field_detail = f"{indent}\033[92m{field_name}: {field_type}{default_str}\033[0m {comment}"
         comments[field_name] = field_detail
         comment_cache = []
 
@@ -149,7 +150,7 @@ def get_fields_docstring(dataclass_obj):
     return '\n'.join(docstring)
 
 
-def get_help_message(dataclass_obj, help_message=""):
+def get_help_message(dataclass_obj, help_message="", **kwargs):
     heading = """
 This script uses Hydra (https://hydra.cc/) for dynamic configuration management.
 You can apply Hydra's command-line syntax for overriding configuration values directly.
@@ -157,6 +158,7 @@ Below are the available configuration options and their default values:
     """.strip()
 
     docstring = get_fields_docstring(dataclass_obj)
+    docstring = docstring.format(**kwargs)
 
     full_help = f"{heading}\n{'-' * 75}\n{docstring}"
     if help_message:

--- a/pipeline/launcher.py
+++ b/pipeline/launcher.py
@@ -28,6 +28,11 @@ from time import sleep
 import yaml
 
 LOG = logging.getLogger(__file__)
+WRAPPER_HELP = """
+This is a wrapper script that will help to launch a pipeline job. You can find the job configuration
+arguments under the "wrapper arguments" section. You can also customize any of the arguments of
+the underlying script, which are listed under the "script arguments" section.
+""".strip()
 
 
 def fill_env_vars(format_dict, env_vars):

--- a/pipeline/run_eval.py
+++ b/pipeline/run_eval.py
@@ -19,9 +19,9 @@ from pathlib import Path
 # adding nemo_skills to python path to avoid requiring installation
 sys.path.append(str(Path(__file__).absolute().parents[1]))
 
-from launcher import CLUSTER_CONFIG, NEMO_SKILLS_CODE, get_server_command, launch_job
+from launcher import CLUSTER_CONFIG, NEMO_SKILLS_CODE, get_server_command, launch_job, WRAPPER_HELP
 
-from nemo_skills.inference.prompt.utils import examples_map, prompt_types
+from nemo_skills.inference.generate_solutions import HELP_MESSAGE
 from nemo_skills.utils import setup_logging
 
 
@@ -70,26 +70,27 @@ JOB_NAME = "eval-{model_name}"
 
 if __name__ == "__main__":
     setup_logging(disable_hydra_logs=False)
-    parser = ArgumentParser()
-    parser.add_argument("--model_path", required=True)
-    parser.add_argument("--server_type", choices=('nemo', 'tensorrt_llm'), default='tensorrt_llm')
-    parser.add_argument("--output_dir", required=True)
-    parser.add_argument("--num_gpus", type=int, required=True)
-    parser.add_argument("--starting_seed", type=int, default=0)
-    parser.add_argument(
+    parser = ArgumentParser(usage=WRAPPER_HELP + '\n\nscript arguments:\n\n' + HELP_MESSAGE)
+    wrapper_args = parser.add_argument_group('wrapper arguments')
+    wrapper_args.add_argument("--model_path", required=True)
+    wrapper_args.add_argument("--server_type", choices=('nemo', 'tensorrt_llm'), default='tensorrt_llm')
+    wrapper_args.add_argument("--output_dir", required=True)
+    wrapper_args.add_argument("--num_gpus", type=int, required=True)
+    wrapper_args.add_argument("--starting_seed", type=int, default=0)
+    wrapper_args.add_argument(
         "--benchmarks",
         nargs="+",
         default=[],
         help="Need to be in a format <benchmark>:<num samples for majority voting>. "
         "Use <benchmark>:0 to only run greedy decoding.",
     )
-    parser.add_argument(
+    wrapper_args.add_argument(
         "--num_nodes",
         type=int,
         default=-1,
         help="Will parallelize across this number of nodes. Set -1 to run each decoding on a separate node.",
     )
-    parser.add_argument(
+    wrapper_args.add_argument(
         "--partition",
         required=False,
         help="Can specify if need interactive jobs or a specific non-default partition",

--- a/pipeline/run_eval.py
+++ b/pipeline/run_eval.py
@@ -24,6 +24,16 @@ from launcher import CLUSTER_CONFIG, NEMO_SKILLS_CODE, get_server_command, launc
 from nemo_skills.inference.generate_solutions import HELP_MESSAGE
 from nemo_skills.utils import setup_logging
 
+SCRIPT_HELP = """
+This script can be used to run evaluation of a model on a set of benchmarks.
+It can run both greedy decoding and sampling and can parallelize generations
+across multiple nodes. It uses nemo_skills/inference/generate_solutions.py
+to generate solutions and nemo_skills/evaluation/evaluate_results.py to
+evaluate them. It will set reasonable defaults for most of the generation parameters,
+but you can override any of them by directly providing corresponding arguments
+in the Hydra format.
+"""
+
 
 def get_greedy_cmd(benchmark, output_name='output-greedy.jsonl', extra_arguments=""):
     return f"""echo "Evaluating benchmark {benchmark}" && \
@@ -67,10 +77,9 @@ fi \
 MOUNTS = "{NEMO_SKILLS_CODE}:/code,{model_path}:/model,{output_dir}:/results"
 JOB_NAME = "eval-{model_name}"
 
-
 if __name__ == "__main__":
     setup_logging(disable_hydra_logs=False)
-    parser = ArgumentParser(usage=WRAPPER_HELP + '\n\nscript arguments:\n\n' + HELP_MESSAGE)
+    parser = ArgumentParser(usage=WRAPPER_HELP + '\n\n' + SCRIPT_HELP + '\n\nscript arguments:\n\n' + HELP_MESSAGE)
     wrapper_args = parser.add_argument_group('wrapper arguments')
     wrapper_args.add_argument("--model_path", required=True)
     wrapper_args.add_argument("--server_type", choices=('nemo', 'tensorrt_llm'), default='tensorrt_llm')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ dependencies = [
   'tqdm',
   'pyyaml',
   'numpy',
+  'requests',
+  'sympy',
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Some improvements to automatic dataclass -> cmd help:
1. Added arbitrary kwargs that can be passed into the get_help_message function and can be used to format variables in the help. E.g. it's currently used to provide choices for the datasets as well as extra server arguments that are parsed from BaseModel docs.
2. Added additional help_message parameter that can be used to further customized help with extra instructions on top of auto dataclass docs.
3. Passed in help from generate_solutoins.py into run_evals.py as an example of how we can handle pipeline script docs
4. Added some coloring + a bit improved format for the cmd docs to make arguments more visible.

Please try to see the help for those scripts and let me know if it looks good or if you'd like to change something!
```
python pipeline/run_eval.py --help
python nemo_skills/inference/generate_solutions.py --help
```

I will work on writing docs for other files in the meantime.