### PR TITLE
Retry on error

### DIFF
--- a/nemo_skills/inference/generate_solutions.py
+++ b/nemo_skills/inference/generate_solutions.py
@@ -25,8 +25,8 @@ from tqdm import tqdm
 
 from nemo_skills.code_execution.sandbox import get_sandbox, sandbox_params
 from nemo_skills.inference.prompt.utils import Prompt, PromptConfig, datasets, prompt_types
-from nemo_skills.inference.server.model import get_model, server_params
-from nemo_skills.utils import get_help_message, setup_logging
+from nemo_skills.inference.server.model import ErrorRecoveryConfig, get_model, server_params
+from nemo_skills.utils import get_fields_docstring, get_help_message, setup_logging
 
 LOG = logging.getLogger(__file__)
 
@@ -46,7 +46,7 @@ class GenerateSolutionsConfig:
     """Top-level parameters for the script"""
 
     output_file: str  # Where to save the generations
-    # Inference server configuration {server_params}
+    # Inference server configuration {server_params} {error_recovery_params}
     server: dict
     # Sandbox configuration {sandbox_params}
     sandbox: dict
@@ -144,12 +144,20 @@ def generate_solutions(cfg: GenerateSolutionsConfig):
                 fout.write(json.dumps(output) + "\n")
 
 
+error_recovery_params = '\n' + get_fields_docstring(
+    ErrorRecoveryConfig,
+    prefix='server.error_recovery.',
+    level=2,
+)
+
+
 HELP_MESSAGE = get_help_message(
     GenerateSolutionsConfig,
     datasets=datasets,
     prompt_types=prompt_types,
     server_params=server_params(),
     sandbox_params=sandbox_params(),
+    error_recovery_params=error_recovery_params,
 )
 
 

--- a/nemo_skills/inference/server/model.py
+++ b/nemo_skills/inference/server/model.py
@@ -194,23 +194,23 @@ class BaseModel(abc.ABC):
                         if result['error_message']:
                             new_outputs[idx]['error_message'] = result['error_message']
                             if self.stop_on_code_error:
-                                new_outputs[idx]['full_prompt'].generate_solutions += output
+                                new_outputs[idx]['full_prompt'].generated_solutions += output
                                 continue
                             text_only_part = output.split(CODE_SEPARATORS[0])[0]
-                            new_outputs[idx]['full_prompt'].generate_solutions += text_only_part
+                            new_outputs[idx]['full_prompt'].generated_solutions += text_only_part
                             code_output = self.__recover_from_error(request, new_outputs[idx], executor)
                             # if re-generation did not help
                             if code_output is None:
                                 code_output = result["result"]
-                                new_outputs[idx]['full_prompt'].generate_solutions += output[len(text_only_part) :]
+                                new_outputs[idx]['full_prompt'].generated_solutions += output[len(text_only_part) :]
                         else:
-                            new_outputs[idx]['full_prompt'].generate_solutions += output
+                            new_outputs[idx]['full_prompt'].generated_solutions += output
                             new_outputs[idx]['error_message'] = ''
                             code_output = result["result"]
 
                         # adding code output to the prompt
                         code_output = f'\n{CODE_OUTPUT_SEPARATORS[0]}\n{code_output}\n{CODE_OUTPUT_SEPARATORS[1]}\n'
-                        new_outputs[idx]['full_prompt'].generate_solutions += code_output
+                        new_outputs[idx]['full_prompt'].generated_solutions += code_output
                         # setting a limit on max code executions to speed things up
                         # (sometimes keeps repeating the same sequence forever)
                         if num_executions >= self.max_code_executions:
@@ -218,7 +218,7 @@ class BaseModel(abc.ABC):
                         else:
                             new_ids.append(idx)
                     else:
-                        new_outputs[idx]['full_prompt'].generate_solutions += output
+                        new_outputs[idx]['full_prompt'].generated_solutions += output
                 remaining_ids = new_ids
 
         # removing original prompt and stop tokens from the end of the generated text

--- a/nemo_skills/inference/server/model.py
+++ b/nemo_skills/inference/server/model.py
@@ -280,12 +280,12 @@ class BaseModel(abc.ABC):
                     session_id=new_output['session_id'],
                 )
 
-            if not self.error_recovery.majority_voting:
-                result, _ = futures[rs].result()
-                # quit on first correct output if not majority voting
-                if not result['error_message']:
-                    results[rs] = result['result']
-                    break
+                if not self.error_recovery.majority_voting:
+                    result, _ = futures[rs].result()
+                    # quit on first correct output if not majority voting
+                    if not result['error_message']:
+                        results[rs] = result['result']
+                        break
 
         for idx, output in enumerate(outputs):
             if not output.endswith(CODE_SEPARATORS[-1]) or not self.error_recovery.majority_voting:

--- a/nemo_skills/inference/server/model.py
+++ b/nemo_skills/inference/server/model.py
@@ -194,23 +194,23 @@ class BaseModel(abc.ABC):
                         if result['error_message']:
                             new_outputs[idx]['error_message'] = result['error_message']
                             if self.stop_on_code_error:
-                                new_outputs[idx]['full_prompt'].generated_solutions += output
+                                new_outputs[idx]['full_prompt'].generated_solution += output
                                 continue
                             text_only_part = output.split(CODE_SEPARATORS[0])[0]
-                            new_outputs[idx]['full_prompt'].generated_solutions += text_only_part
+                            new_outputs[idx]['full_prompt'].generated_solution += text_only_part
                             code_output = self.__recover_from_error(request, new_outputs[idx], executor)
                             # if re-generation did not help
                             if code_output is None:
                                 code_output = result["result"]
-                                new_outputs[idx]['full_prompt'].generated_solutions += output[len(text_only_part) :]
+                                new_outputs[idx]['full_prompt'].generated_solution += output[len(text_only_part) :]
                         else:
-                            new_outputs[idx]['full_prompt'].generated_solutions += output
+                            new_outputs[idx]['full_prompt'].generated_solution += output
                             new_outputs[idx]['error_message'] = ''
                             code_output = result["result"]
 
                         # adding code output to the prompt
                         code_output = f'\n{CODE_OUTPUT_SEPARATORS[0]}\n{code_output}\n{CODE_OUTPUT_SEPARATORS[1]}\n'
-                        new_outputs[idx]['full_prompt'].generated_solutions += code_output
+                        new_outputs[idx]['full_prompt'].generated_solution += code_output
                         # setting a limit on max code executions to speed things up
                         # (sometimes keeps repeating the same sequence forever)
                         if num_executions >= self.max_code_executions:
@@ -218,7 +218,7 @@ class BaseModel(abc.ABC):
                         else:
                             new_ids.append(idx)
                     else:
-                        new_outputs[idx]['full_prompt'].generated_solutions += output
+                        new_outputs[idx]['full_prompt'].generated_solution += output
                 remaining_ids = new_ids
 
         # removing original prompt and stop tokens from the end of the generated text
@@ -278,7 +278,7 @@ class BaseModel(abc.ABC):
 
         most_common = counts.most_common(1)[0][0]
         valid_idx = results.index(most_common)
-        new_output['full_prompt'] += outputs[valid_idx]
+        new_output['full_prompt'].generated_solution += outputs[valid_idx]
         new_output['error_message'] = ''
 
         return most_common

--- a/nemo_skills/inference/server/model.py
+++ b/nemo_skills/inference/server/model.py
@@ -84,6 +84,7 @@ class BaseModel(abc.ABC):
         handle_code_execution: Optional[bool] = True - Whether to handle code execution in this class
             or make a single call to the server. If set to False, the server needs to have special logic
             for communicating with the sandbox.
+        error_recovery: Optional[dict] = None - Configuration for error recovery.
     """
 
     def __init__(
@@ -96,9 +97,9 @@ class BaseModel(abc.ABC):
         max_code_output_characters=1000,
         code_execution_timeout=10.0,
         max_code_executions=3,
-        error_recovery=None,
         stop_on_code_error=True,
         handle_code_execution=True,
+        error_recovery=None,
     ):
         self.server_host = host
         self.server_port = port
@@ -379,7 +380,9 @@ class NemoModel(BaseModel):
             ]
             for arg in unsupported_arguments:
                 if arg in kwargs:
-                    raise ValueError(f"`{arg}` is not supported by NemoModel.")
+                    raise ValueError(
+                        f"`{arg}` is not supported by NemoModel if handle_code_execution=False. To use it, set handle_code_execution=True."
+                    )
 
         super().__init__(**kwargs)
 

--- a/nemo_skills/inference/server/model.py
+++ b/nemo_skills/inference/server/model.py
@@ -96,7 +96,7 @@ class BaseModel(abc.ABC):
         max_code_output_characters=1000,
         code_execution_timeout=10.0,
         max_code_executions=3,
-        error_recovery_args={},
+        error_recovery_config={},
         stop_on_code_error=True,
         handle_code_execution=True,
     ):
@@ -107,7 +107,7 @@ class BaseModel(abc.ABC):
         self.max_code_output_characters = max_code_output_characters
         self.code_execution_timeout = code_execution_timeout
         self.max_code_executions = max_code_executions
-        self.error_recovery_args = ErrorRecoveryConfig(**error_recovery_args)
+        self.error_recovery_args = ErrorRecoveryConfig(**error_recovery_config)
         self.handle_code_execution = handle_code_execution
         self.stop_on_code_error = stop_on_code_error
         if self.handle_code_execution and sandbox is None:

--- a/nemo_skills/utils.py
+++ b/nemo_skills/utils.py
@@ -81,7 +81,7 @@ def type_to_str(type_hint):
         return str(type_hint).replace('typing.', '')
 
 
-def extract_comments_above_fields(dataclass_obj, prefix: str = '', level: int = 0):
+def extract_comments_above_fields(dataclass_obj, prefix: str = '', level: int = 0, **kwargs):
     source_lines = inspect.getsource(dataclass_obj).split('\n')
     fields_info = {
         field.name: {
@@ -144,8 +144,8 @@ def extract_comments_above_fields(dataclass_obj, prefix: str = '', level: int = 
     return comments
 
 
-def get_fields_docstring(dataclass_obj):
-    commented_fields = extract_comments_above_fields(dataclass_obj)
+def get_fields_docstring(dataclass_obj, **kwargs):
+    commented_fields = extract_comments_above_fields(dataclass_obj, **kwargs)
     docstring = [content for content in commented_fields.values()]
     return '\n'.join(docstring)
 


### PR DESCRIPTION
This PR allows to recover from errors by re-generating failed code blocks and do majority voting on their outputs. Using `error_recovery_attempts=10` and `stop_on_code_error=False` we can improve OpenMath-Mistral-7b results from 44.5 to 46.56 on math.