### PR TITLE
Provide an way to launch a HF model on VLLM directly by HF name

### DIFF
--- a/nemo_skills/inference/prompt/utils.py
+++ b/nemo_skills/inference/prompt/utils.py
@@ -206,8 +206,27 @@ class Prompt:
 
 
 def get_prompt_config(prompt_type: str) -> PromptConfig:
+    """
+    Reads the prompt config from the yaml file.
+
+    Args:
+        prompt_type: The name of the prompt config file. Can be the path to a yaml file or one of the available configs.
+
+    Returns:
+        The prompt config object.
+    """
     # reading prompt format from the yaml file, if not running through hydra
-    config_path = Path(__file__).parent / f"{prompt_type}.yaml"
+    internal_config_path = Path(__file__).parent / f"{prompt_type}.yaml"
+    if internal_config_path.exists():
+        config_path = internal_config_path
+
+    elif ".yaml" in prompt_type:
+        # Assume prompt type is a str to a filepath
+        config_path = Path(prompt_type).absolute()
+
+    else:
+        raise ValueError(f"Prompt config not found for {prompt_type}")
+
     with open(config_path, "rt", encoding="utf-8") as fin:
         prompt_config = PromptConfig(_init_nested=True, **yaml.safe_load(fin))
         return prompt_config

--- a/nemo_skills/inference/server/model.py
+++ b/nemo_skills/inference/server/model.py
@@ -312,7 +312,7 @@ class VLLMModel(BaseModel):
         tokens_to_generate: int = 512,
         temperature: float = 0.0,
         top_p: float = 0.95,
-        top_k: int = 0,
+        top_k: int = -1,
         repetition_penalty: float = 1.0,
         random_seed: int = 0,
         stop_phrases: list[str] | None = None,
@@ -348,7 +348,7 @@ class VLLMModel(BaseModel):
         max_tokens: int,
         temperature: float,
         top_p: float,
-        top_k: int = 1,
+        top_k: int = -1,
         num_generations: int = 1,
         stop=None,
         echo: bool = False,
@@ -366,7 +366,7 @@ class VLLMModel(BaseModel):
         # Process top_k
         extra_body = {
             "extra_body": {
-                "top_k": 1,
+                "top_k": top_k,
                 "repetition_penalty": repetition_penalty,
                 "spaces_between_special_tokens": False,
             }

--- a/pipeline/launcher.py
+++ b/pipeline/launcher.py
@@ -59,7 +59,7 @@ def get_server_command(server_type: str, num_gpus: int, num_nodes: int, model_na
             num_tasks = 1
 
     elif server_type == 'vllm':
-        if len(model_name.split('/')) == 2:
+        if len(model_name.split('/')) == 2 and not os.path.exists(model_name):
             server_start_cmd = (
                 f"NUM_GPUS={num_gpus} bash /code/nemo_skills/inference/server/serve_vllm.sh "
                 f"{model_name} {model_name} 0 openai 5000"

--- a/pipeline/launcher.py
+++ b/pipeline/launcher.py
@@ -59,10 +59,16 @@ def get_server_command(server_type: str, num_gpus: int, num_nodes: int, model_na
             num_tasks = 1
 
     elif server_type == 'vllm':
-        server_start_cmd = (
-            f"NUM_GPUS={num_gpus} bash /code/nemo_skills/inference/server/serve_vllm.sh "
-            f"/model/ {model_name} 0 openai 5000"
-        )
+        if len(model_name.split('/')) == 2:
+            server_start_cmd = (
+                f"NUM_GPUS={num_gpus} bash /code/nemo_skills/inference/server/serve_vllm.sh "
+                f"{model_name} {model_name} 0 openai 5000"
+            )
+        else:
+            server_start_cmd = (
+                f"NUM_GPUS={num_gpus} bash /code/nemo_skills/inference/server/serve_vllm.sh "
+                f"/model/ {model_name} 0 openai 5000"
+            )
         num_tasks = 1
     else:
         # adding sleep to ensure the logs file exists

--- a/pipeline/start_server.py
+++ b/pipeline/start_server.py
@@ -102,6 +102,9 @@ if __name__ == "__main__":
     if os.path.exists(args.model_path):
         MOUNTS += f",{args.model_path}:/model"
 
+    if os.environ.get("HF_HOME", None) is not None:
+        MOUNTS += f",{os.environ['HF_HOME']}:/cache/huggingface"
+
     job_id = launch_job(
         cmd=SLURM_CMD.format(**format_dict),
         num_nodes=args.num_nodes,

--- a/pipeline/start_server.py
+++ b/pipeline/start_server.py
@@ -23,7 +23,7 @@ from pathlib import Path
 try:
     from huggingface_hub import get_token
 except (ImportError, ModuleNotFoundError):
-    get_token = lambda: os.environ.get('HF_TOKEN', None)
+    get_token = lambda: os.environ.get('HF_TOKEN', '')
 
 # adding nemo_skills to python path to avoid requiring installation
 sys.path.append(str(Path(__file__).absolute().parents[1]))

--- a/pipeline/start_server.py
+++ b/pipeline/start_server.py
@@ -19,6 +19,7 @@ import sys
 import time
 from argparse import ArgumentParser
 from pathlib import Path
+
 from huggingface_hub import get_token
 
 # adding nemo_skills to python path to avoid requiring installation
@@ -78,8 +79,10 @@ if __name__ == "__main__":
         args.model_path = Path(args.model_path).absolute()
 
     server_start_cmd, num_tasks, server_wait_string = get_server_command(
-        args.server_type, args.num_gpus, args.num_nodes,
-        args.model_path.name if os.path.exists(args.model_path) else args.model_path
+        args.server_type,
+        args.num_gpus,
+        args.num_nodes,
+        args.model_path.name if os.path.exists(args.model_path) else args.model_path,
     )
 
     # TODO: VLLM


### PR DESCRIPTION
# Changelog

- Provide a way to simply use "HF" name of a model for VLLM codepath, so that local development can conveniently switch models without having to apriori download the model directory explicitly