### PR TITLE
Revert commit af9bd3b: Edge case for trt llm out-of-vocabulary

### DIFF
--- a/nemo_skills/inference/server/serve_trt.py
+++ b/nemo_skills/inference/server/serve_trt.py
@@ -160,9 +160,6 @@ def get_output_single(output_ids, input_length, max_output_len, tokenizer, eos_t
     if len(eos_ids) > 0:
         outputs = outputs[: eos_ids[0]]
     outputs = outputs.tolist()
-    # somehow sometimes it produces tokens out of range..
-    outputs = [elem if elem < tokenizer.vocab_size else tokenizer.vocab_size - 1 for elem in outputs]
-    outputs = [elem if 0 <= elem else 0 for elem in outputs]
     return tokenizer.decode(outputs)
 
 


### PR DESCRIPTION
This PR reverts changes introduced in this commit: https://github.com/Kipok/NeMo-Skills/commit/af9bd3b9d5590918350a35cb9b8b549f14486040, which adds lines that handle out-of-range IDs which are not needed now as the TensorRT-LLM bug has been fixed. Also, `tokenizer.vocab_size` doesn't take special tokens into consideration and thus may impact the generation of special tokens.