### PR TITLE
Changing evalplus install commit to support MBPP v0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 backoff
-evalplus
+git+https://github.com/evalplus/evalplus@c91370f
 huggingface_hub
 hydra-core
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 backoff
-git+https://github.com/evalplus/evalplus@c91370f
+evalplus @ git+https://github.com/evalplus/evalplus@c91370f
 huggingface_hub
 hydra-core
 numpy


### PR DESCRIPTION
Evalplus installation commit to support MBPPv0.2