### PR TITLE
Integrating arena-hard benchmark

### DIFF
--- a/datasets/arena-hard/prepare.py
+++ b/datasets/arena-hard/prepare.py
@@ -47,6 +47,5 @@ if __name__ == "__main__":
             data['baseline_answer'] = baseline_answers[data['question_id']]
             # will be filled by the evaluation script
             data['judgements'] = []
-            data['judge_scores'] = []
 
             fout.write(json.dumps(data) + "\n")

--- a/datasets/arena-hard/prepare.py
+++ b/datasets/arena-hard/prepare.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import urllib.request
+from pathlib import Path
+
+URL_QUESTIONS = "https://raw.githubusercontent.com/lm-sys/arena-hard-auto/main/data/arena-hard-v0.1/question.jsonl"
+URL_BASELINE = (
+    "https://raw.githubusercontent.com/lm-sys/arena-hard-auto/main/data/arena-hard-v0.1/model_answer/gpt-4-0314.jsonl"
+)
+
+
+if __name__ == "__main__":
+    data_folder = Path(__file__).absolute().parent
+    data_folder.mkdir(exist_ok=True)
+    questions = str(data_folder / "question.jsonl")
+    baseline = str(data_folder / "gpt-4-0314.jsonl")
+    output_file = str(data_folder / "test.jsonl")
+    urllib.request.urlretrieve(URL_QUESTIONS, questions)
+    urllib.request.urlretrieve(URL_BASELINE, baseline)
+
+    baseline_answers = {}
+    with open(baseline, "rt", encoding="utf-8") as fin:
+        for line in fin:
+            data = json.loads(line)
+            assert len(data['choices']) == 1
+            assert len(data['choices'][0]['turns']) == 1
+            baseline_answers[data['question_id']] = data['choices'][0]['turns'][0]['content']
+
+    with open(questions, "rt", encoding="utf-8") as fin, open(output_file, "wt", encoding="utf-8") as fout:
+        for line in fin:
+            data = json.loads(line)
+            assert len(data['turns']) == 1
+            data['question'] = data.pop('turns')[0]['content']
+            data['baseline_answer'] = baseline_answers[data['question_id']]
+            fout.write(json.dumps(data) + "\n")

--- a/datasets/arena-hard/prepare.py
+++ b/datasets/arena-hard/prepare.py
@@ -45,4 +45,8 @@ if __name__ == "__main__":
             assert len(data['turns']) == 1
             data['question'] = data.pop('turns')[0]['content']
             data['baseline_answer'] = baseline_answers[data['question_id']]
+            # will be filled by the evaluation script
+            data['judgements'] = []
+            data['judge_scores'] = []
+
             fout.write(json.dumps(data) + "\n")

--- a/datasets/arena-hard/prepare.py
+++ b/datasets/arena-hard/prepare.py
@@ -47,5 +47,7 @@ if __name__ == "__main__":
             data['baseline_answer'] = baseline_answers[data['question_id']]
             # will be filled by the evaluation script
             data['judgements'] = []
+            # original code sets different temperature for different categories
+            # TODO: do we need to do the same or greedy is good enough?
 
             fout.write(json.dumps(data) + "\n")

--- a/datasets/arena-hard/prepare.py
+++ b/datasets/arena-hard/prepare.py
@@ -45,8 +45,6 @@ if __name__ == "__main__":
             assert len(data['turns']) == 1
             data['question'] = data.pop('turns')[0]['content']
             data['baseline_answer'] = baseline_answers[data['question_id']]
-            # will be filled by the evaluation script
-            data['judgements'] = []
             # original code sets different temperature for different categories
             # TODO: do we need to do the same or greedy is good enough?
 

--- a/nemo_skills/code_execution/sandbox.py
+++ b/nemo_skills/code_execution/sandbox.py
@@ -26,6 +26,7 @@ from typing import Dict, List, Optional, Tuple
 import backoff
 import requests
 
+from nemo_skills.code_execution.math_grader import extract_answer
 from nemo_skills.utils import python_doc_to_cmd_help, unroll_files
 
 LOG = logging.getLogger(__file__)
@@ -330,7 +331,7 @@ print(json.dumps({{"result": output, "error_message": error_message}}))
                     gt_answer = line_dict["expected_answer"]
                     data[-1][-1] = json.dumps(line_dict)
 
-                    predicted_answer = line_dict.get("predicted_answer", Sandbox.NOT_EXECUTED)
+                    predicted_answer = extract_answer(line_dict)
                     if (predicted_answer, gt_answer) in map_to_future:
                         continue
 

--- a/nemo_skills/evaluation/arena_utils.py
+++ b/nemo_skills/evaluation/arena_utils.py
@@ -98,7 +98,7 @@ def get_battles_from_judgment(scores, WEIGHT=3):
 
     for score in scores:
         # game 1
-        output = {"model_a": "baseline", "model_b": 'candidate'}
+        output = {"model_a": "candidate", "model_b": 'baseline'}
 
         assert len(score) == 2
         cur_score = score[0]
@@ -124,7 +124,7 @@ def get_battles_from_judgment(scores, WEIGHT=3):
             arena_hard_battles = pd.concat([arena_hard_battles, pd.DataFrame([output] * weight)])
 
         # game 2
-        output = {"model_a": "baseline", "model_b": 'candidate'}
+        output = {"model_a": "candidate", "model_b": 'baseline'}
 
         cur_score = score[1]
 

--- a/nemo_skills/evaluation/arena_utils.py
+++ b/nemo_skills/evaluation/arena_utils.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# adapted from https://github.com/lm-sys/arena-hard-auto/blob/main/show_result.py
+
+import inspect
+import json
+import math
+from collections import defaultdict
+
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+
+
+def compute_mle_elo(df, SCALE=400, BASE=10, INIT_RATING=1000):
+    models = pd.concat([df["model_a"], df["model_b"]]).unique()
+    models = pd.Series(np.arange(len(models)), index=models)
+
+    # duplicate battles
+    df = pd.concat([df, df], ignore_index=True)
+    p = len(models.index)
+    n = df.shape[0]
+
+    X = np.zeros([n, p])
+    X[np.arange(n), models[df["model_a"]]] = +math.log(BASE)
+    X[np.arange(n), models[df["model_b"]]] = -math.log(BASE)
+
+    # one A win => two A win
+    Y = np.zeros(n)
+    Y[df["winner"] == "model_a"] = 1.0
+
+    # one tie => one A win + one B win
+    # find tie + tie (both bad) index
+    tie_idx = (df["winner"] == "tie") | (df["winner"] == "tie (bothbad)")
+    tie_idx[len(tie_idx) // 2 :] = False
+    Y[tie_idx] = 1.0
+
+    lr = LogisticRegression(fit_intercept=False, penalty=None, tol=1e-8)
+    lr.fit(X, Y)
+
+    elo_scores = SCALE * lr.coef_[0] + INIT_RATING
+
+    # set anchor as gpt-4-0314 = 1000
+    if "baseline" in models.index:
+        elo_scores += 1000 - elo_scores[models["baseline"]]
+    return pd.Series(elo_scores, index=models.index).sort_values(ascending=False)
+
+
+def get_bootstrap_result(battles, func_compute_elo, num_round):
+    rows = []
+    kwargs = {}
+    if "baseline" in inspect.signature(func_compute_elo).parameters:
+        kwargs["baseline"] = "baseline"
+    for _ in range(num_round):
+        rows.append(func_compute_elo(battles.sample(frac=1.0, replace=True), **kwargs))
+    df = pd.DataFrame(rows)
+    return df[df.median().sort_values(ascending=False).index]
+
+
+def predict_win_rate(elo_ratings, SCALE=400, BASE=10, INIT_RATING=1000):
+    names = sorted(list(elo_ratings.keys()))
+    wins = defaultdict(lambda: defaultdict(lambda: 0))
+    for a in names:
+        for b in names:
+            ea = 1 / (1 + BASE ** ((elo_ratings[b] - elo_ratings[a]) / SCALE))
+            wins[a][b] = ea
+            wins[b][a] = 1 - ea
+
+    data = {a: [wins[a][b] if a != b else np.NAN for b in names] for a in names}
+
+    df = pd.DataFrame(data, index=names)
+    df.index.name = "model_a"
+    df.columns.name = "model_b"
+    return df.T
+
+
+def get_win_rate_column(df, column):
+    to_dict = df[["model", column]].set_index("model").to_dict()[column]
+    win_rate_table = predict_win_rate(to_dict)
+    return win_rate_table["baseline"].fillna(0.5).apply(lambda x: round(x * 100, 2))
+
+
+def get_battles_from_judgment(scores, WEIGHT=3):
+    arena_hard_battles = pd.DataFrame()
+    num_invalid = 0
+
+    for score in scores:
+        # game 1
+        output = {"model_a": "baseline", "model_b": 'candidate'}
+
+        assert len(score) == 2
+        cur_score = score[0]
+
+        weight = 1
+        if cur_score == "A=B":
+            output["winner"] = "tie"
+        elif cur_score == "A>B":
+            output["winner"] = "model_a"
+        elif cur_score == "A>>B":
+            output["winner"] = "model_a"
+            weight = WEIGHT
+        elif cur_score == "B>A":
+            output["winner"] = "model_b"
+        elif cur_score == "B>>A":
+            output["winner"] = "model_b"
+            weight = WEIGHT
+        else:
+            num_invalid += 1
+            weight = 0
+
+        if weight:
+            arena_hard_battles = pd.concat([arena_hard_battles, pd.DataFrame([output] * weight)])
+
+        # game 2
+        output = {"model_a": "baseline", "model_b": 'candidate'}
+
+        cur_score = score[1]
+
+        weight = 1
+        if cur_score == "A=B":
+            output["winner"] = "tie"
+        elif cur_score == "A>B":
+            output["winner"] = "model_b"
+        elif cur_score == "A>>B":
+            output["winner"] = "model_b"
+            weight = WEIGHT
+        elif cur_score == "B>A":
+            output["winner"] = "model_a"
+        elif cur_score == "B>>A":
+            output["winner"] = "model_a"
+            weight = WEIGHT
+        else:
+            num_invalid += 1
+            weight = 0
+
+        if weight:
+            arena_hard_battles = pd.concat([arena_hard_battles, pd.DataFrame([output] * weight)])
+    return arena_hard_battles, num_invalid
+
+
+def get_aggregate_score(scores, weight=3):
+    battles, num_invalid = get_battles_from_judgment(scores, weight)
+    bootstrap_online_elo = compute_mle_elo(battles)
+
+    np.random.seed(42)
+    num_rounds = 100
+    bootstrap_elo_lu = get_bootstrap_result(battles, compute_mle_elo, num_rounds)
+
+    stats = pd.DataFrame()
+    stats["results"] = None
+    stats["results"] = stats['results'].astype('object')
+
+    for i, model in enumerate(bootstrap_online_elo.index):
+        assert model in bootstrap_elo_lu.columns
+
+        stats.at[i, "model"] = model
+        stats.at[i, "score"] = bootstrap_online_elo[model]
+        stats.at[i, "lower"] = np.percentile(bootstrap_elo_lu[model], 2.5)
+        stats.at[i, "upper"] = np.percentile(bootstrap_elo_lu[model], 97.5)
+        stats.at[i, "results"] = bootstrap_elo_lu[model].tolist()
+
+    stats.sort_values(by="model", inplace=True)
+    stats["score"] = get_win_rate_column(stats, "score").tolist()
+    stats["lower"] = get_win_rate_column(stats, "lower").tolist()
+    stats["upper"] = get_win_rate_column(stats, "upper").tolist()
+
+    candidate_stats = stats[stats['model'] == 'candidate']
+    interval = (
+        round((candidate_stats['lower'] - candidate_stats['score']).iloc[0], 2),
+        round((candidate_stats['upper'] - candidate_stats['score']).iloc[0], 2),
+    )
+    metrics = {
+        'score': candidate_stats['score'].iloc[0],
+        '95_CI': interval,
+        'invalid_scores': num_invalid,
+    }
+    return metrics

--- a/nemo_skills/evaluation/evaluate_results.py
+++ b/nemo_skills/evaluation/evaluate_results.py
@@ -38,7 +38,7 @@ class EvaluateResultsConfig:
     # Sandbox configuration {sandbox_params}
     sandbox: dict = field(default_factory=lambda: {'sandbox_type': 'local'})
 
-    eval_type: str = "math"  # math or code  TODO: benchmark?
+    eval_type: str = "math"
     eval_config: dict = field(default_factory=dict)
 
     def __post_init__(self):
@@ -62,6 +62,7 @@ def evaluate_results(cfg: EvaluateResultsConfig):
     GRADING_MAP[cfg.eval_type](cfg)
 
 
+# TODO: sandbox should be inside the eval_config
 HELP_MESSAGE = get_help_message(
     EvaluateResultsConfig,
     sandbox_params=sandbox_params(),

--- a/nemo_skills/evaluation/graders.py
+++ b/nemo_skills/evaluation/graders.py
@@ -18,6 +18,7 @@ import shutil
 import subprocess
 from argparse import Namespace
 from pathlib import Path
+from typing import Optional
 
 from nemo_skills.utils import nested_dataclass, unroll_files
 
@@ -118,7 +119,7 @@ class ArenaGraderConfig:
     batch_size: int = 100  # lower if running into rate limits
     tokens_to_generate: int = 4096  # will auto-lower to max possible for NGC models
     use_batch_api: bool = True  # only supported for OpenAI models!
-    base_url: str | None = None
+    base_url: Optional[str] = None
     judge_model: str = "gpt-4-1106-preview"
     # defaults to True to avoid regenerating judgements unless necessary
     skip_filled: bool = True

--- a/nemo_skills/evaluation/graders.py
+++ b/nemo_skills/evaluation/graders.py
@@ -112,18 +112,6 @@ def if_grader(cfg):
 
 
 def arena_grader(cfg):
-    def get_score(judgment):
-        pattern = re.compile('\[\[([AB<>=]+)\]\]')
-        # adapted from https://github.com/lm-sys/arena-hard-auto/blob/main/gen_judgment.py
-        matches = pattern.findall(judgment)
-        matches = [m for m in matches if m != ""]
-        if len(set(matches)) == 0:
-            return None
-        elif len(set(matches)) == 1:
-            return matches[0].strip("\n")
-        else:
-            return None
-
     # currently only support api models for simplicity
     def write_judgements(data_file, judge_model='gpt-4-1106-preview', base_url=None, batch_size=10):
         data_file = Path(data_file).absolute()
@@ -151,7 +139,6 @@ def arena_grader(cfg):
 
         for sample, judgement in zip(samples, judgements):
             sample['judgements'].append(judgement)
-            sample['judge_scores'].append(get_score(judgement))
 
         # writing back to the original file without -tmp
         with open(str(data_file)[:-4], "wt", encoding="utf-8") as fout:

--- a/nemo_skills/evaluation/graders.py
+++ b/nemo_skills/evaluation/graders.py
@@ -173,10 +173,12 @@ def arena_grader(cfg):
                 prompts=[prompt.build_string(data_point) for data_point in data_points],
                 tokens_to_generate=eval_config.tokens_to_generate,
             )
-            print(request_metadata)
             # saving the request id to be able to retrieve results when they are ready
             with open(jsonl_file + '-batch-request-id', 'wt', encoding='utf-8') as fout:
                 fout.write(json.dumps({'request_id': request_metadata.id}))
+            LOG.info('Submitted batch evaluation request to OpenAI. Please wait for the results to be ready.')
+            LOG.info('The current status and final results can be accessed through summarize_results.py')
+            LOG.info('Request metadata: %s', str(request_metadata))
         else:
             output_file = jsonl_file + '-judgement'
             starting_idx = 0

--- a/nemo_skills/evaluation/metrics.py
+++ b/nemo_skills/evaluation/metrics.py
@@ -216,7 +216,7 @@ class ArenaEval:
         self.total += 1
         self.scores.append([])
         if aggregation_mode == "best":
-            judge_scores = [self._get_judge_score(elem['judgements'][0]) for elem in predictions]
+            judge_scores = [self._get_judge_score(elem['judgement-gen-base']) for elem in predictions]
             # adding the best score out of all the generations
             possible_scores = ['A>>B', 'A>B', 'A=B', 'B>A', 'B>>A']
             for possible_score in possible_scores:
@@ -229,7 +229,7 @@ class ArenaEval:
             else:
                 self.scores[-1].append(None)  # in case judge didn't generate a valid score
 
-            judge_scores = [self._get_judge_score(elem['judgements'][1]) for elem in predictions]
+            judge_scores = [self._get_judge_score(elem['judgement-base-gen']) for elem in predictions]
             # second score is grading swapped answers, so we iterate from the end
             for possible_score in possible_scores[::-1]:
                 # picking the best available score
@@ -242,7 +242,10 @@ class ArenaEval:
                 self.scores[-1].append(None)  # in case judge didn't generate a valid score
         elif aggregation_mode == "first":
             self.lengths += len(predictions[0]['generation'])
-            self.scores[-1] = [self._get_judge_score(judgement) for judgement in predictions[0]['judgements']]
+            self.scores[-1] = [
+                self._get_judge_score(predictions[0]['judgement-gen-base']),
+                self._get_judge_score(predictions[0]['judgement-base-gen']),
+            ]
         else:
             raise ValueError(f"Unsupported mode {aggregation_mode}")
 

--- a/nemo_skills/evaluation/metrics.py
+++ b/nemo_skills/evaluation/metrics.py
@@ -299,6 +299,8 @@ class ArenaEval(BaseEval):
     def get_metrics(self):
         # run the score aggregation using arena-hard logic
         # currently needs sklearn, which is not ideal, but let's just error-out if it's not installed
+        # it's also not going to work on clusters unless there is python 3.10 and all packages are installed
+        # so currently need to be done inside the container or with some custom setup
         try:
             from nemo_skills.evaluation.arena_utils import get_aggregate_score
         except ImportError:

--- a/nemo_skills/evaluation/settings.py
+++ b/nemo_skills/evaluation/settings.py
@@ -17,7 +17,7 @@
 # to happen in eval_map.py inside prompt folder for specific models
 
 from nemo_skills.evaluation.graders import arena_grader, code_grader, if_grader, math_grader
-from nemo_skills.evaluation.metrics import CodeEval, IFEval, MathEval
+from nemo_skills.evaluation.metrics import ArenaEval, CodeEval, IFEval, MathEval
 
 MATH_BENCHMARKS = [
     'algebra222',
@@ -41,6 +41,7 @@ CODE_BENCHMARKS = ['human-eval', 'mbpp']
 # ------------------------------- metrics settings -----------------------------
 EVALUATOR_MAP = {
     "ifeval": IFEval,
+    "arena-hard": ArenaEval,
     "mmlu": MathEval,  # TODO: update this
 }
 

--- a/nemo_skills/evaluation/settings.py
+++ b/nemo_skills/evaluation/settings.py
@@ -16,7 +16,7 @@
 # in addition to what's in this file, there is also some prompt engineering that needs
 # to happen in eval_map.py inside prompt folder for specific models
 
-from nemo_skills.evaluation.graders import code_eval, ifeval, math_eval
+from nemo_skills.evaluation.graders import arena_grader, code_grader, if_grader, math_grader
 from nemo_skills.evaluation.metrics import CodeEval, IFEval, MathEval
 
 MATH_BENCHMARKS = [
@@ -57,13 +57,15 @@ EXTRA_EVAL_ARGS = {
     'human-eval': '++eval_type=code ++eval_config.dataset=humaneval',
     'mbpp': '++eval_type=code ++eval_config.dataset=mbpp',
     'ifeval': '++eval_type=ifeval',
+    'arena-hard': '++eval_type=arena',
 }
 
 # TODO: better name?
 GRADING_MAP = {
-    "math": math_eval,  # that's default. TODO: should we do this per-benchmark?
-    "code": code_eval,
-    "ifeval": ifeval,
+    "math": math_grader,  # that's default. TODO: should we do this per-benchmark?
+    "code": code_grader,
+    "ifeval": if_grader,
+    "arena": arena_grader,
 }
 # ------------------------------------------------------------------------------
 

--- a/nemo_skills/inference/generate_solutions.py
+++ b/nemo_skills/inference/generate_solutions.py
@@ -22,7 +22,6 @@ import hydra
 from tqdm import tqdm
 
 from nemo_skills.code_execution import extract_error_message
-from nemo_skills.code_execution.math_grader import extract_answer
 from nemo_skills.code_execution.sandbox import get_sandbox, sandbox_params
 from nemo_skills.inference.prompt.utils import Prompt, PromptConfig, datasets, prompt_types
 from nemo_skills.inference.server.code_execution_model import (
@@ -90,12 +89,6 @@ cs = hydra.core.config_store.ConfigStore.instance()
 cs.store(name="base_generation_config", node=GenerateSolutionsConfig)
 
 
-def add_answer_and_error_message(output: dict):
-    output['predicted_answer'] = extract_answer(output['generation'])
-    if 'error_message' not in output:
-        output['error_message'] = extract_error_message(output['generation'])
-
-
 @hydra.main(version_base=None, config_name='generation_config', config_path='.')
 def generate_solutions(cfg: GenerateSolutionsConfig):
     cfg = GenerateSolutionsConfig(_init_nested=True, **cfg)
@@ -152,8 +145,8 @@ def generate_solutions(cfg: GenerateSolutionsConfig):
                     # to make it easier to follow up with evaluation and limit accidental errors, we are adding
                     # all of the ground-truth data to the output file alongside the generated solutions
                     output.update(original_data_point)
-                    # adding answer and error message
-                    add_answer_and_error_message(output)
+                    if 'error_message' not in output:
+                        output['error_message'] = extract_error_message(output['generation'])
 
                     if cfg.generation_key != "generation":
                         output[cfg.generation_key] = output.pop("generation")
@@ -170,7 +163,8 @@ def generate_solutions(cfg: GenerateSolutionsConfig):
             )
             for output, original_data_point in zip(outputs, data_points):
                 output.update(original_data_point)
-                add_answer_and_error_message(output)
+                if 'error_message' not in output:
+                    output['error_message'] = extract_error_message(output['generation'])
                 if cfg.generation_key != "generation":
                     output[cfg.generation_key] = output.pop("generation")
                 fout.write(json.dumps(output) + "\n")

--- a/nemo_skills/inference/prompt/llama3/eval_map.py
+++ b/nemo_skills/inference/prompt/llama3/eval_map.py
@@ -26,6 +26,7 @@ EVAL_MAP = {
         'mbpp': 'llama3/codegen',
         'mmlu': 'llama3/mmlu',
         'ifeval': 'llama3/sft',
+        'arena-hard': 'llama3/sft',
     },
     'instruct-nemo': {  # llama3-instruct finetuned with nemo_skills
         'default': 'llama3/sft',

--- a/nemo_skills/inference/prompt/openai/arena-judge.yaml
+++ b/nemo_skills/inference/prompt/openai/arena-judge.yaml
@@ -1,0 +1,43 @@
+# from https://github.com/lm-sys/arena-hard-auto/blob/main/config/judge_config.yaml
+
+system: |-
+  Please act as an impartial judge and evaluate the quality of the responses provided by two AI assistants to the user prompt displayed below. You will be given assistant A's answer and assistant B's answer. Your job is to evaluate which assistant's answer is better.
+
+  Begin your evaluation by generating your own answer to the prompt. You must provide your answers before judging any answers.
+
+  When evaluating the assistants' answers, compare both assistants' answers with your answer. You must identify and correct any mistakes or inaccurate information.
+
+  Then consider if the assistant's answers are helpful, relevant, and concise. Helpful means the answer correctly responds to the prompt or follows the instructions. Note when user prompt has any ambiguity or more than one interpretation, it is more helpful and appropriate to ask for clarifications or more information from the user than providing an answer based on assumptions. Relevant means all parts of the response closely connect or are appropriate to what is being asked. Concise means the response is clear and not verbose or excessive.
+
+  Then consider the creativity and novelty of the assistant's answers when needed. Finally, identify any missing important information in the assistants' answers that would be beneficial to include when responding to the user prompt.
+
+  After providing your explanation, you must output only one of the following choices as your final verdict with a label:
+
+  1. Assistant A is significantly better: [[A>>B]]
+  2. Assistant A is slightly better: [[A>B]]
+  3. Tie, relatively the same: [[A=B]]
+  4. Assistant B is slightly better: [[B>A]]
+  5. Assistant B is significantly better: [[B>>A]]
+
+  Example output: "My final verdict is tie: [[A=B]]".
+
+user: |-
+    <|User Prompt|>
+    {question}
+
+    <|The Start of Assistant A's Answer|>
+    {answer_1}
+    <|The End of Assistant A's Answer|>
+
+    <|The Start of Assistant B's Answer|>
+    {answer_2}
+    <|The End of Assistant B's Answer|>
+
+# <..._start> and <..._end> are special tokens that are not directly visible to the model.
+# They are used to parse the prompt into parts in our inference pipeline.
+prompt_template: |-
+  <system_start>{system}<system_end>
+  <user_start>{user}<user_end>
+  <assistant_start>{generation}
+
+stop_phrases: []  # automatically stops on turn token

--- a/pipeline/run_eval.py
+++ b/pipeline/run_eval.py
@@ -78,6 +78,8 @@ nvidia-smi && \
 cd /code && \
 export PYTHONPATH=$PYTHONPATH:/code && \
 export HF_TOKEN={HF_TOKEN} && \
+export NVIDIA_API_KEY={NVIDIA_API_KEY} && \
+export OPENAI_API_KEY={OPENAI_API_KEY} && \
 if [ $SLURM_PROCID -eq 0 ]; then \
     {{ {server_start_cmd} 2>&1 | tee /tmp/server_logs.txt & }} && sleep 1 && \
     echo "Waiting for the server to start" && \
@@ -175,7 +177,10 @@ if __name__ == "__main__":
         "server_start_cmd": server_start_cmd,
         "server_type": args.server_type,
         "NEMO_SKILLS_CODE": NEMO_SKILLS_CODE,
-        "HF_TOKEN": os.getenv("HF_TOKEN", ""),  # needed for some of the models, so making an option to pass it in
+        # needed for some of the models, so making an option to pass it in
+        "HF_TOKEN": os.getenv("HF_TOKEN", ""),
+        "OPENAI_API_KEY": os.getenv("OPENAI_API_KEY", ""),
+        "NVIDIA_API_KEY": os.getenv("NVIDIA_API_KEY", ""),
         "server_wait_string": server_wait_string,
     }
 

--- a/pipeline/run_labeling.py
+++ b/pipeline/run_labeling.py
@@ -29,6 +29,8 @@ nvidia-smi && \
 cd /code && \
 export PYTHONPATH=$PYTHONPATH:/code && \
 export HF_TOKEN={HF_TOKEN} && \
+export NVIDIA_API_KEY={NVIDIA_API_KEY} && \
+export OPENAI_API_KEY={OPENAI_API_KEY} && \
 if [ $SLURM_PROCID -eq 0 ]; then \
     {{ {server_start_cmd} 2>&1 | tee /tmp/server_logs.txt & }} && sleep 1 && \
     echo "Waiting for the server to start" && \
@@ -137,7 +139,10 @@ if __name__ == "__main__":
         "server_type": args.server_type,
         "extra_eval_args": args.extra_eval_args,
         "NEMO_SKILLS_CODE": NEMO_SKILLS_CODE,
-        "HF_TOKEN": os.getenv("HF_TOKEN", ""),  # needed for some of the models, so making an option to pass it in
+        # needed for some of the models, so making an option to pass it in
+        "HF_TOKEN": os.getenv("HF_TOKEN", ""),
+        "OPENAI_API_KEY": os.getenv("OPENAI_API_KEY", ""),
+        "NVIDIA_API_KEY": os.getenv("NVIDIA_API_KEY", ""),
         "server_wait_string": server_wait_string,
     }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,6 @@ openai
 pyyaml
 rank_bm25
 requests
+scikit-learn
 sympy
 tqdm


### PR DESCRIPTION
Arena hard is the first benchmark where we need to run an LLM to do evaluation, so this PR has quite a bit of changes. For future LLM-as-a-judge benchmarks we should be able to reuse a lot of the logic add here.

Some important details.
1. I'm not getting exactly the same scores as in the original repo, but the relative difference between llama3-8b and 70b is the same. My scores are 26 / 52 and their scores are 20 / 46. There are two potential reasons - one is they have a retry mechanism when gpt-4 doesn't produce an answer and I currently didn't implement that, so there are 2-3% of missing grades. Second, they use different temperature for different categories, and we only use greedy for simplicity and reproducibility.
2. To run the evaluation you'd need to define OPENAI_API_KEY env var. What's going to happen by default is we will submit a batch request which is going to send all the data at once to openai to avoid rate limits and also decrease the cost. Then when you run summarize results, we will check if the request is finished and stop if not. If it is finished the script will fetch the data and include in the generation file, so that it's complete and proceed to report metrics. The problem here is that it requires openai/python10 to be installed where you're running this and so it might not work on slurm login nodes. So either we need to run it in an interactive job or by pulling data to some local machine.
3. Another way to run the evaluation is through NGC hosted models, e.g. with llama3-70b. I found that the scores are very different than with gpt-4, so that might not be a good idea, but can still serve as some quick and cheap way to get the numbers. To do that, the following additional arguments need to be provided. 
```
--extra_eval_args "\
  ++eval_config.judge_model="meta/llama3-70b-instruct" \
  ++eval_config.base_url="https://integrate.api.nvidia.com/v1" \
  ++eval_config.use_batch_api=False \
"
```
This will run the evaluation synchronously, but it's very fast since we submit 100 requests in parallel and this can be increased further (but might run into rate limits at some point). For this to work you also need to define NVIDIA_API_KEY variable