### PR TITLE
Remove `tokenizer_type` when loading a tokenizer using AutoTokenizer

### DIFF
--- a/nemo_skills/inference/server/serve_trt.py
+++ b/nemo_skills/inference/server/serve_trt.py
@@ -178,7 +178,6 @@ def load_tokenizer(tokenizer_dir: str, model_name: str):
     else:
         tokenizer = AutoTokenizer.from_pretrained(
             tokenizer_dir,
-            tokenizer_type=model_name,
             legacy=False,
             padding_side='left',
             truncation_side='left',

--- a/nemo_skills/inference/server/serve_trt.py
+++ b/nemo_skills/inference/server/serve_trt.py
@@ -195,12 +195,9 @@ def load_tokenizer(tokenizer_dir: str, model_name: str):
 def read_model_name(config):
     name = config['pretrained_config']['architecture'].lower()
     name_map = {
-        'MistralForCausalLM'.lower(): 'mistral',
-        'LlamaForCausalLM'.lower(): 'llama',
-        'MixtralForCausalLM'.lower(): 'mixtral',
         'GPTForCausalLM'.lower(): 'gpt-next',
     }
-    return name_map[name]
+    return name_map.get(name, None)
 
 
 def generate(


### PR DESCRIPTION
This PR removes the `tokenizer_type` passed to `AutoTokenizer.from_pretrained()`, which is no longer required by recent models such as Llama 3 and Mistral Nemo 12B.