### PR TITLE
push decontaminator code

### DIFF
--- a/nemo_skills/evaluation/graders.py
+++ b/nemo_skills/evaluation/graders.py
@@ -20,6 +20,8 @@ from argparse import Namespace
 from dataclasses import asdict, field
 from pathlib import Path
 from typing import Optional
+import pdb
+
 
 from nemo_skills.utils import nested_dataclass, unroll_files
 
@@ -58,6 +60,23 @@ class MathGraderConfig:
     extract_from_boxed: bool = True
     # only used if extract_from_boxed is False
     extract_regex: str = r"The final answer is (.+)$"
+
+
+
+@nested_dataclass
+class DecontaminatorConfig:
+    # Sandbox configuration {sandbox_params}
+    grading_type: str = "llm"  # sympy or llm
+    grading_config: dict = field(default_factory=dict)
+
+    extract_from_boxed: bool = True
+    # only used if extract_from_boxed is False
+    extract_regex: str = r"The final answer is (.+)$"
+
+
+
+
+
 
 
 def math_grader(cfg):
@@ -105,7 +124,7 @@ def math_grader(cfg):
             continue
 
         data_points = []
-
+        print(data)
         if grading_config.use_batch_api:
             for data_point in data:
                 # adding required fields for judgement prompt
@@ -372,3 +391,105 @@ def arena_grader(cfg):
 
             # removing judgement file
             Path(output_file).unlink()
+
+
+
+
+def contaminator_grader(cfg):
+    eval_config = DecontaminatorConfig(**cfg.eval_config)
+    
+
+    from tqdm import tqdm
+
+    from nemo_skills.code_execution.math_grader import extract_answer
+    from nemo_skills.inference.prompt.utils import Prompt, get_prompt_config
+    from nemo_skills.inference.server.model import get_model
+
+    grading_config = LlmGraderConfig(**eval_config.grading_config)
+
+    if grading_config.use_batch_api and grading_config.base_url:
+        raise ValueError("Batch API is only supported for OpenAI models!")
+
+    llm = get_model(
+        server_type='openai',
+        base_url=grading_config.base_url,
+        model=grading_config.judge_model,
+    )
+    prompt = Prompt(config=get_prompt_config('openai/math-detect-zero-shot'))
+    
+    # assuming everything fits in memory for simplicity
+    for jsonl_file in unroll_files(cfg.prediction_jsonl_files):
+        with open(jsonl_file, 'rt', encoding='utf-8') as fin:
+            data = [json.loads(line) for line in fin]
+
+
+        # TODO: should we try to judge both ways here as well? How to aggregate?
+        if grading_config.skip_filled and all('judgement' in data_point for data_point in data):
+            continue
+
+        data_points = []
+        
+        if grading_config.use_batch_api:
+            for data_point in data:
+                # adding required fields for judgement prompt
+                to_add = data_point.copy()
+                data_points.append(to_add)
+
+            request_metadata = llm.batch_generate(
+                prompts=[prompt.build_string(data_point) for data_point in data_points],
+                tokens_to_generate=grading_config.tokens_to_generate,
+            )
+            # saving the request id to be able to retrieve results when they are ready
+            with open(jsonl_file + '-batch-request-id', 'wt', encoding='utf-8') as fout:
+                fout.write(json.dumps({'request_id': request_metadata.id}))
+            LOG.info('Submitted batch evaluation request to OpenAI. Please wait for the results to be ready.')
+            LOG.info('The current status and final results can be accessed through summarize_results.py')
+            LOG.info('Request metadata: %s', str(request_metadata))
+        else:
+            output_file = jsonl_file + '-judgement'
+            starting_idx = 0
+            if grading_config.skip_filled:
+                try:
+                    with open(output_file, "rt", encoding="utf-8") as fin:
+                        starting_idx = len(fin.readlines())
+                except FileNotFoundError:
+                    LOG.warning(f"File `{output_file}` not found, starting from scratch")
+            data = data[starting_idx:]
+
+            # saving to a tmp file to avoid corrupting original generation in case something goes wrong
+            with open(
+                output_file, "at" if grading_config.skip_filled else "wt", encoding="utf-8", buffering=1
+            ) as fout:
+                for data_point in tqdm(data, initial=starting_idx, total=len(data) + starting_idx):
+                    # adding required fields for judgement prompt
+                    to_add = data_point.copy()
+                    
+                    data_points.append(to_add)
+
+                    if len(data_points) == grading_config.batch_size:
+                        outputs = llm.generate(
+                            prompts=[prompt.build_string(data_point) for data_point in data_points],
+                            tokens_to_generate=grading_config.tokens_to_generate,
+                        )
+                        for output in outputs:
+                            fout.write(json.dumps({'judgement': output['generation']}) + "\n")
+                        data_points = []
+
+                # collecting the final batch
+                if len(data_points) > 0:
+                    outputs = llm.generate(
+                        prompts=[prompt.build_string(data_point) for data_point in data_points],
+                        tokens_to_generate=grading_config.tokens_to_generate,
+                    )
+                    for output in outputs:
+                        fout.write(json.dumps({'judgement': output['generation']}) + "\n")
+
+            # fusing back into original file
+            with open(jsonl_file, 'wt', encoding='utf-8') as fout, open(output_file, 'rt', encoding='utf-8') as fin:
+                for data_point, judgement_line in zip(data, fin):
+                    data_point.update(json.loads(judgement_line))
+                    fout.write(json.dumps(data_point) + "\n")
+
+            # removing judgement file
+            Path(output_file).unlink()
+

--- a/nemo_skills/evaluation/retrieve_similar_question.py
+++ b/nemo_skills/evaluation/retrieve_similar_question.py
@@ -1,0 +1,169 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+import sys
+from collections import Counter
+from itertools import zip_longest
+from typing import Any
+
+import hydra
+from omegaconf import MISSING
+from tqdm import tqdm
+
+from nemo_skills.evaluation.metrics import MathEval, read_predictions
+from nemo_skills.utils import get_help_message, nested_dataclass, setup_logging
+import torch
+from sentence_transformers import SentenceTransformer, util
+import collections
+import glob
+import numpy as np
+import pdb
+LOG = logging.getLogger(__file__)
+
+
+
+def unroll_files(prediction_jsonl_files):
+    files = []
+    for file_pattern in prediction_jsonl_files:
+        matched_files = sorted(glob.glob(file_pattern, recursive=True))
+        files.extend(matched_files)
+    return files
+
+def top_k_similarity(train_embs, test_embs, top_k):
+    # Compute cosine-similarities
+    cosine_scores = util.cos_sim(test_embs, train_embs)
+    # Find the top-k most similar train_embs for each test_emb
+    top_k_indices = torch.topk(cosine_scores, k=top_k, dim=1).indices
+
+    return top_k_indices
+
+
+def bert_encode(model, data, batch_size=32, device=None):
+    return model.encode(data, batch_size=batch_size, show_progress_bar=True, device=device)
+
+
+def read_dataset_question(r_path):
+    with open(r_path, 'r', encoding='utf-8') as file:
+        return [json.loads(line)['question'] for line in file]
+
+
+def read_dataset(r_path):
+    with open(r_path, 'r', encoding='utf-8') as file:
+        return [json.loads(line) for line in file]
+
+
+
+
+@nested_dataclass
+class LLMDecontaminatorConfig:
+    """Top-level parameters for the script"""
+
+    # list of files to use for llm contamination detection.
+    # Can specify multiple patterns separated by space
+    # e.g. "path/to/file1.jsonl path/to/file2.jsonl" or with regex
+    # "train_folder/output-rs*.jsonl"
+    train_jsonl_files: Any = MISSING
+
+    # "test_folder/output-rs*.jsonl"
+    test_jsonl_files: Any = MISSING
+    
+    ### the model used to compute embedding, default is sentence transformer
+    model: str = 'multi-qa-MiniLM-L6-cos-v1'
+    
+    ### the number of devices to coompute embedding
+    device: Any = MISSING
+    
+    ### for each question in the test data set, we retreive the top_k similar questions from the train_jsonl_files
+    top_k: int = 3
+
+    batch_size: int = 32
+    
+    def __post_init__(self):
+        """Building data_file from dataset/split_name if not provided directly."""
+        if isinstance(self.train_jsonl_files, str):
+            self.train_jsonl_files = self.train_jsonl_files.split(" ")
+        
+        # if isinstance(self.test_jsonl_files, str):
+        #     self.test_jsonl_files = self.test_jsonl_files.split(" ")
+    
+    
+
+
+cs = hydra.core.config_store.ConfigStore.instance()
+cs.store(name="base_llm_decontaminator_detect_conifg", node=LLMDecontaminatorConfig)
+
+
+@hydra.main(version_base=None, config_name="base_llm_decontaminator_detect_conifg")
+def compute_embedding(cfg: LLMDecontaminatorConfig):
+    cfg = LLMDecontaminatorConfig(_init_nested=True, **cfg)
+    LOG.info("Config used: %s", cfg)
+
+    file_handles = unroll_files(cfg.train_jsonl_files)
+
+    model = SentenceTransformer(cfg.model)
+    test_cases = read_dataset_question(cfg.test_jsonl_files)
+    test_embs = bert_encode(model,  test_cases, batch_size=cfg.batch_size, device=cfg.device)
+    db_embedding = collections.defaultdict(list)
+    db_questions = collections.defaultdict(list)
+    for file_path in file_handles:
+        train_cases = read_dataset_question(file_path)
+        train_embs = bert_encode(model, train_cases, batch_size=cfg.batch_size, device=cfg.device)
+        top_k_indices = top_k_similarity(train_embs, test_embs, cfg.top_k)
+        
+        
+        
+        for i, test_case in enumerate(test_cases):
+            #### for each file in the training, we will find the top_k similar examples
+            top_k_embedding_per_file = [train_embs[index] for index in top_k_indices[i]]
+            top_k_questions_per_file = [train_cases[index] for index in top_k_indices[i]]
+            db_embedding[i].extend(top_k_embedding_per_file)  
+            db_questions[i].extend(top_k_questions_per_file) 
+    
+    test_file = read_dataset(cfg.test_jsonl_files)
+    for i, test_case in enumerate(test_cases):
+        test_embs_i = test_embs[i].reshape(1, len(test_embs[i]))
+        db_embedding[i] = np.array(db_embedding[i])
+        #### we will select top_k similar examples from top_k * len(training files)
+        top_k_indices = top_k_similarity(db_embedding[i], test_embs_i, cfg.top_k)
+
+        similar_exmaple = []
+        for index in top_k_indices.tolist()[0]:
+            #### get source file index, suppose we have 10 files, and top_k = 2
+            #### then index belong [0, 19], so index // top_k belong [0, 9]
+            train_file_index = index // cfg.top_k
+            ##### db_questions[i] stores top_k*10 similar question, and we can directly retrevie the question
+            pair = {'source': file_handles[train_file_index], 'question': db_questions[i][index]}
+            similar_exmaple.append(pair)
+        test_file[i]['top_k_similar_example'] = similar_exmaple
+    
+    
+    #### we will write back to the orginal files
+    with open(cfg.test_jsonl_files, 'w', encoding='utf-8') as file:
+        for entry in test_file:
+            #### currently we only support top_1 as the candate
+            entry['candidate'] = entry['top_k_similar_example'][0]['question']
+            file.write(json.dumps(entry, ensure_ascii=False) + '\n')
+
+
+HELP_MESSAGE = get_help_message(LLMDecontaminatorConfig)
+
+
+if __name__ == "__main__":
+    if '--help' in sys.argv or '-h' in sys.argv:
+        print(HELP_MESSAGE)
+    else:
+        setup_logging()
+        compute_embedding()

--- a/nemo_skills/evaluation/settings.py
+++ b/nemo_skills/evaluation/settings.py
@@ -16,7 +16,7 @@
 # in addition to what's in this file, there is also some prompt engineering that needs
 # to happen in eval_map.py inside prompt folder for specific models
 
-from nemo_skills.evaluation.graders import arena_grader, code_grader, if_grader, math_grader, contaminator_grader
+from nemo_skills.evaluation.graders import arena_grader, code_grader, contaminator_grader, if_grader, math_grader
 from nemo_skills.evaluation.metrics import ArenaEval, CodeEval, IFEval, MathEval
 
 MATH_BENCHMARKS = [

--- a/nemo_skills/evaluation/settings.py
+++ b/nemo_skills/evaluation/settings.py
@@ -16,7 +16,7 @@
 # in addition to what's in this file, there is also some prompt engineering that needs
 # to happen in eval_map.py inside prompt folder for specific models
 
-from nemo_skills.evaluation.graders import arena_grader, code_grader, if_grader, math_grader
+from nemo_skills.evaluation.graders import arena_grader, code_grader, if_grader, math_grader, contaminator_grader
 from nemo_skills.evaluation.metrics import ArenaEval, CodeEval, IFEval, MathEval
 
 MATH_BENCHMARKS = [
@@ -68,6 +68,7 @@ GRADING_MAP = {
     "code": code_grader,
     "ifeval": if_grader,
     "arena": arena_grader,
+    "contaminator": contaminator_grader,
 }
 # ------------------------------------------------------------------------------
 

--- a/nemo_skills/inference/prompt/openai/math-detect-few-shot.yaml
+++ b/nemo_skills/inference/prompt/openai/math-detect-few-shot.yaml
@@ -1,0 +1,51 @@
+# from https://github.com/openai/simple-evals/blob/main/common.py
+
+system: ""
+
+user: |-
+    
+    I will now give you two questions Original question and Candidate question, please help me determine if the following two questions are the same.
+    Here are a few examples:
+
+    Example 1:
+    Original question: A scientist needs 65 liters of a 15% alcohol solution. She has available a 25% and a 12% solution. How many liters of the 25% solution should she mix to make the 15% solution?
+    Candidate question: A scientist needs 65 liters of a 15% alcohol solution. She has available a 25% and a 12% solution. How many liters of the 25% and how many liters of the 12% solutions should she mix to make the 15% solution?
+    True
+
+
+    Example 2:
+    Original question: Leo is planning his spring flower garden. He wants to plant tulip and daffodil bulbs. He will plant 6 times as many daffodil bulbs as tulip bulbs. If he wants to plant 350 bulbs, how many tulip bulbs should he plant?
+    Candidate question: Leo is planning his spring flower garden. He wants to plant tulip and daffodil bulbs. He will plant 6 times as many daffodil bulbs as tulip bulbs. If he wants to plant 350 bulbs, how many tulip bulbs and how many daffodil bulbs should he plant?
+    True
+
+    Example 3:
+    Original question: Every Monday Helen shares coffee and donuts with the office where she works. One week Helen buys 4 cups of coffee and 6 donuts, and pays 18 dollars. The next week Helen buys 6 cups of coffee and 12 donuts, and pays 30 dollars. Find the price of one cup of coffee.
+    Candidate question: 'Coffee Noriko bought 4 coffees for herself and her co-workers. Each coffee was $3.75. How much did she pay for all the coffees?'
+    False
+
+
+
+    Example 4:
+    Original question: art, Millhouse, and Martin Prince saved up 149 dollars for a collectible comic book. Find how much money Bart saved up if Bart contributed 3 times less than Millhouse, and Martin contributed 9 dollars more than Millhouse.
+    Candidate question: Miranda got $40 from her ATM. She spent $9.32 on lunch and $16.99 on a book. How much money did she have left? Round to the nearest cent if necessary.
+    False
+    
+    
+    Original question: {question}
+    Candidate question: {candidate}
+
+    Please use the provided examples to assess whether the two questions below are identical.
+    Original question: {question}
+    Candidate question: {candidate}
+
+    Disregard the names and minor changes in word order that appear within.
+    If their question prompts are very similar and, without considering the solution process, they produce the same answer, we consider them to be the same question.
+    Please respond with only "True" or "False" based on your judgment. Do not respond with anything else.
+
+
+prompt_template: |-
+  <system_start>{system}<system_end>
+  <user_start>{user}<user_end>
+  <assistant_start>{generation}
+
+stop_phrases: []  # automatically stops on turn token

--- a/nemo_skills/inference/prompt/openai/math-detect-zero-shot.yaml
+++ b/nemo_skills/inference/prompt/openai/math-detect-zero-shot.yaml
@@ -1,0 +1,22 @@
+# from https://github.com/openai/simple-evals/blob/main/common.py
+
+system: ""
+
+user: |-
+    
+    I will now give you two questions Original question and Candidate question, please help me determine if the following two questions are the same.
+    
+    Original question: {question}
+    Candidate question: {candidate}
+
+    Disregard the names and minor changes in word order that appear within.
+    If their question prompts are very similar and, without considering the solution process, they produce the same answer, we consider them to be the same question.
+    Please respond with only "True" or "False" based on your judgment. Do not respond with anything else.
+
+
+prompt_template: |-
+  <system_start>{system}<system_end>
+  <user_start>{user}<user_end>
+  <assistant_start>{generation}
+
+stop_phrases: []  # automatically stops on turn token


### PR DESCRIPTION
I developed a pipeline to extract similar questions from the training data corresponding to the test data.

We can use the following command to retrieve similar questions, which will then be saved back to the original_test.jsonl file.

```
python nemo_skills/evaluation/retrieve_similar_question.py \
  train_jsonl_files=/home/wedu/workspace/gsm8k-augmentation-questions/output*.jsonl \
  test_jsonl_files=/home/wedu/workspace/NeMo-Skills/datasets/gsm8k/original_test.jsonl \
  model=multi-qa-MiniLM-L6-cos-v1 \
  device=cuda
```


I also created two yaml files for the LLM to determine whether the question from the test set and the candidate question are rephrased versions of each other.
nemo_skills/inference/prompt/openai/math-detect-few-shot.yaml
nemo_skills/inference/prompt/openai/math-detect-zero-shot.yaml

We can leverage the generate_solutions.py code if we host our Llama-405B model as outlined below:

```
python nemo_skills/inference/generate_solutions.py \
    output_file=/home/wedu/workspace/NeMo-Skills/datasets/gsm8k/test_405b_few_shot_gsm8k-augmentation-questions.jsonl \
    +prompt=openai/math-detect-few-shot \
    ++dataset=gsm8k \
    ++split_name=original_test \
    ++max_samples=5000 \
    ++server.server_type=tensorrt_llm \
    ++server.host=batch-block1-1075 \
    ++sandbox.host=batch-block1-1075 \
    ++batch_size=512
```

I also created a contaminator type similar to our math-grader if we want to use GPT-4 directly. We can also use GPT-4 using the following command:
```
python nemo_skills/evaluation/evaluate_results.py \
    prediction_jsonl_files=/home/wedu/workspace/NeMo-Skills/datasets/gsm8k/test_405b_zero_shot.jsonl  \
    eval_type=contaminator \
    ++eval_config.grading_type=llm \
    ++eval_config.grading_config.skip_filled=False \
    ++eval_config.grading_config.batch_size=50
```