### PR TITLE
Add support for env variable passthrough and env variable mounting

### DIFF
--- a/nemo_skills/inference/server/model.py
+++ b/nemo_skills/inference/server/model.py
@@ -445,6 +445,9 @@ class VLLMModel(BaseModel):
             api_key="EMPTY", base_url=f"http://{self.server_host}:{self.server_port}/v1", timeout=None
         )
 
+        self.model_name_server = self.get_model_name_from_server()
+        self.model = self.model_name_server
+
     def generate(
         self,
         prompts: list[str | dict],
@@ -513,7 +516,7 @@ class VLLMModel(BaseModel):
             }
         }
         response = self.oai_client.completions.create(
-            model='self-hosted-model',
+            model=self.model,
             prompt=prompt,
             max_tokens=max_tokens,
             temperature=temperature,
@@ -549,6 +552,11 @@ class VLLMModel(BaseModel):
                     output += choice.stop_reason
                 responses.append(output)
         return responses
+
+    def get_model_name_from_server(self):
+        model_list = self.oai_client.models.list()
+        model_name = model_list.data[0].id
+        return model_name
 
 
 models = {

--- a/nemo_skills/pipeline/check_contamination.py
+++ b/nemo_skills/pipeline/check_contamination.py
@@ -101,7 +101,7 @@ if __name__ == "__main__":
     if args.server_address is None:  # we need to host the model
         assert args.server_gpus is not None, "Need to specify server_gpus if hosting the model"
         args.server_address = "localhost:5000"
-        check_if_mounted(cluster_config, args.model)
+
         server_config = {
             "model_path": args.model,
             "server_type": args.server_type,

--- a/nemo_skills/pipeline/eval.py
+++ b/nemo_skills/pipeline/eval.py
@@ -129,7 +129,7 @@ if __name__ == "__main__":
     if args.server_address is None:  # we need to host the model
         assert args.server_gpus is not None, "Need to specify server_gpus if hosting the model"
         args.server_address = "localhost:5000"
-        check_if_mounted(cluster_config, args.model)
+
         server_config = {
             "model_path": args.model,
             "server_type": args.server_type,

--- a/nemo_skills/pipeline/generate.py
+++ b/nemo_skills/pipeline/generate.py
@@ -110,7 +110,7 @@ if __name__ == "__main__":
     if args.server_address is None:  # we need to host the model
         assert args.server_gpus is not None, "Need to specify server_gpus if hosting the model"
         args.server_address = "localhost:5000"
-        check_if_mounted(cluster_config, args.model)
+
         server_config = {
             "model_path": args.model,
             "server_type": args.server_type,

--- a/nemo_skills/pipeline/llm_math_judge.py
+++ b/nemo_skills/pipeline/llm_math_judge.py
@@ -93,7 +93,7 @@ if __name__ == "__main__":
     if args.server_address is None:  # we need to host the model
         assert args.server_gpus is not None, "Need to specify server_gpus if hosting the model"
         args.server_address = "localhost:5000"
-        check_if_mounted(cluster_config, args.model)
+
         server_config = {
             "model_path": args.model,
             "server_type": args.server_type,

--- a/nemo_skills/pipeline/start_server.py
+++ b/nemo_skills/pipeline/start_server.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os.path
+import os
 from argparse import ArgumentParser
 
 import nemo_run as run

--- a/nemo_skills/pipeline/start_server.py
+++ b/nemo_skills/pipeline/start_server.py
@@ -25,7 +25,7 @@ if __name__ == "__main__":
     parser.add_argument("--config_dir", default=None, help="Path to the cluster_configs dir")
     parser.add_argument("--log_dir", required=False, help="Can specify a custom location for slurm logs")
     parser.add_argument("--cluster", required=True, help="One of the configs inside cluster_configs")
-    parser.add_argument("--model", required=False, default=None, help="Path to the model.")
+    parser.add_argument("--model", required=True, help="Path to the model.")
     parser.add_argument(
         "--server_type",
         choices=('nemo', 'trtllm', 'vllm'),

--- a/nemo_skills/pipeline/start_server.py
+++ b/nemo_skills/pipeline/start_server.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import os.path
 from argparse import ArgumentParser
 
 import nemo_run as run
@@ -25,7 +25,7 @@ if __name__ == "__main__":
     parser.add_argument("--config_dir", default=None, help="Path to the cluster_configs dir")
     parser.add_argument("--log_dir", required=False, help="Can specify a custom location for slurm logs")
     parser.add_argument("--cluster", required=True, help="One of the configs inside cluster_configs")
-    parser.add_argument("--model", required=True, help="Path to the model.")
+    parser.add_argument("--model", required=False, default=None, help="Path to the model.")
     parser.add_argument(
         "--server_type",
         choices=('nemo', 'trtllm', 'vllm'),
@@ -51,7 +51,12 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     cluster_config = get_cluster_config(args.cluster, args.config_dir)
-    check_if_mounted(cluster_config, args.model)
+
+    if args.server_type != "vllm":
+        check_if_mounted(cluster_config, args.model)
+    elif args.server_type == "vllm" and os.path.exists(args.model):
+        check_if_mounted(cluster_config, args.model)
+
     if args.log_dir:
         check_if_mounted(cluster_config, args.log_dir)
 

--- a/nemo_skills/pipeline/start_server.py
+++ b/nemo_skills/pipeline/start_server.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 from argparse import ArgumentParser
 
 import nemo_run as run

--- a/nemo_skills/pipeline/start_server.py
+++ b/nemo_skills/pipeline/start_server.py
@@ -52,11 +52,6 @@ if __name__ == "__main__":
 
     cluster_config = get_cluster_config(args.cluster, args.config_dir)
 
-    if args.server_type != "vllm":
-        check_if_mounted(cluster_config, args.model)
-    elif args.server_type == "vllm" and os.path.exists(args.model):
-        check_if_mounted(cluster_config, args.model)
-
     if args.log_dir:
         check_if_mounted(cluster_config, args.log_dir)
 

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -334,6 +334,7 @@ def get_mounts_from_config(cluster_config: dict, env_vars: dict = None):
         mount_source, mount_target = env_mount.split(":")
 
         if mount_source[0] == "{" and mount_source[-1] == "}":
+            # Resolve the environment variable for the mount source
             mount_source = mount_source[1:-1]
 
             if mount_source not in env_vars:
@@ -344,6 +345,7 @@ def get_mounts_from_config(cluster_config: dict, env_vars: dict = None):
             mount_source = env_vars[mount_source]
 
         if mount_target[0] == "{" and mount_target[-1] == "}":
+            # Resolve the environment variable for the mount target
             mount_target = mount_target[1:-1]
 
             if mount_target not in env_vars:

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -346,23 +346,23 @@ def get_mounts_from_config(cluster_config: dict, env_vars: dict = None):
             # Resolve the environment variable for the mount source
             mount_source = mount_source[1:-1]
 
-            if mount_source not in env_vars:
+            if mount_source not in os.environ:
                 raise ValueError(
                     f"Required environment variable {mount_source} not found in env variables passed in cluster configs."
                 )
 
-            mount_source = env_vars[mount_source]
+            mount_source = os.environ[mount_source]
 
         if mount_target[0] == "{" and mount_target[-1] == "}":
             # Resolve the environment variable for the mount target
             mount_target = mount_target[1:-1]
 
-            if mount_target not in env_vars:
+            if mount_target not in os.environ:
                 raise ValueError(
                     f"Required environment variable {mount_target} not found in env variables passed in cluster configs."
                 )
 
-            mount_target = env_vars[mount_target]
+            mount_target = os.environ[mount_target]
 
         # add the mount to the list of mounts
         resolved_mount = f"{mount_source}:{mount_target}"

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -337,7 +337,9 @@ def get_mounts_from_config(cluster_config: dict, env_vars: dict = None):
             mount_source = mount_source[1:-1]
 
         if mount_source not in env_vars:
-            raise ValueError(f"Required environment variable {mount_source} not found in env variables passed in cluster configs.")
+            raise ValueError(
+                f"Required environment variable {mount_source} not found in env variables passed in cluster configs."
+            )
 
         # add the mount to the list of mounts
         mounts.append(f"{env_vars[mount_source]}:{mount_target}")

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -336,13 +336,25 @@ def get_mounts_from_config(cluster_config: dict, env_vars: dict = None):
         if mount_source[0] == "{" and mount_source[-1] == "}":
             mount_source = mount_source[1:-1]
 
-        if mount_source not in env_vars:
-            raise ValueError(
-                f"Required environment variable {mount_source} not found in env variables passed in cluster configs."
-            )
+            if mount_source not in env_vars:
+                raise ValueError(
+                    f"Required environment variable {mount_source} not found in env variables passed in cluster configs."
+                )
+
+            mount_source = env_vars[mount_source]
+
+        if mount_target[0] == "{" and mount_target[-1] == "}":
+            mount_target = mount_target[1:-1]
+
+            if mount_target not in env_vars:
+                raise ValueError(
+                    f"Required environment variable {mount_target} not found in env variables passed in cluster configs."
+                )
+
+            mount_target = env_vars[mount_target]
 
         # add the mount to the list of mounts
-        mounts.append(f"{env_vars[mount_source]}:{mount_target}")
+        mounts.append(f"{mount_source}:{mount_target}")
 
     return mounts
 


### PR DESCRIPTION
This pr adds a few flags for processing by the server creation engine before it executes

The server config can have the following additional args

- `env_vars`: Optional environ variables that will be copied as is from user environment to execution environment 
- `required_env_vars`: Mandatory environ variables that will be checked for existence before being copied to execution environment
- `env_mounts`: A user defined list mapping from `<STR | ENV_VAR>:<STR | ENV_VAR>`. The engine will resolve the ENV_VAR at runtime, and consider it a mandatory argument to be passed by the user.

This enables for dynamic mounting by the user without the hardcoding of local and slurm mount paths - all users can share the same config file, and simply populate the mount paths via personal environment variables provided in their private .bashrc or .profile (or even explicit export). 

This will reduce the number of copy pasted user-defined versions of the example server configs and prevent users from having to manually maintain and update their configs as and when the core repo updates with newer containers.

# Example

```yaml
# cluster_configs/local.yaml
...

# optional env variables
env_vars: ['NEMO_SKILLS_CONFIG']
# required env variables
required_env_vars: ['HF_HOME', 'HF_TOKEN']

# mounting determined by environment variables
env_mounts:
  - "{HF_HOME}:/cache/huggingface"
```