### PR TITLE
Refactor the logic for cluster config resolution

### DIFF
--- a/docs/common-parameters.md
+++ b/docs/common-parameters.md
@@ -10,7 +10,7 @@ All scripts inside pipeline folder have the following parameters.
   control where the job is executed.
 - **--config_dir**: By default we search for cluster configs inside `cluster_configs`
   local folder, but you can control where they are located with this parameter.
-  You can also use `NEMO_SKILLS_CONFIGS` environment variable for this purpose.
+  You can also use `NEMO_SKILLS_CONFIG_DIR` environment variable for this purpose.
 - **--expname**: You can always specify an experiment name, which is a
   [NeMo-Run](https://github.com/NVIDIA/NeMo-Run) concept. This will control where
   the metadata is stored, what is slurm job name and allows you to chain jobs one

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -39,7 +39,7 @@ your jobs and what to mount in the containers. Please read on to learn more abou
 
 All of the scripts inside [nemo_skills/pipeline](/nemo_skills/pipeline) accept `--cluster` argument which you can use
 to control where the job gets executed. That argument picks up one of the configs inside your local [cluster_configs](/cluster_configs/)
-folder by default, but you can specify another location with `--config_dir` or set it in `NEMO_SKILLS_CONFIGS` env variable.
+folder by default, but you can specify another location with `--config_dir` or set it in `NEMO_SKILLS_CONFIG_DIR` env variable.
 The cluster config defines an executor (local or slurm), mounts for data/model access and (slurm-only) various parameters
 such as account, partition, ssh-tunnel arguments and so on.
 

--- a/nemo_skills/inference/server/model.py
+++ b/nemo_skills/inference/server/model.py
@@ -271,7 +271,9 @@ class OpenAIModel(BaseModel):
         remove_stop_phrases: bool = True,
     ) -> list[dict]:
         if isinstance(prompts[0], str):
-            raise NotImplementedError("OpenAI server requires \"messages\" dicts as prompt.")
+            for pidx in range(len(prompts)):
+                prompts[pidx] = [{"role": "user", "content": prompts[pidx]}]
+
         if stop_phrases is None:
             stop_phrases = []
         if top_k != 0:

--- a/nemo_skills/pipeline/app.py
+++ b/nemo_skills/pipeline/app.py
@@ -83,7 +83,6 @@ def create_remote_directory(directory: str | list, cluster_config: dict):
             logging.info(f"Created directory: {dir_path} in local filesystem.")
         tunnel.cleanup()
 
-
     elif cluster_config.get('executor') == 'slurm':
         ssh_tunnel_config = cluster_config.get('ssh_tunnel', None)
         if ssh_tunnel_config is None:
@@ -94,7 +93,6 @@ def create_remote_directory(directory: str | list, cluster_config: dict):
             tunnel.run(f'mkdir -p {dir_path}', hide=False, warn=True)
             logging.info(f"Created directory: {dir_path} on remote cluster.")
         tunnel.cleanup()
-
 
     else:
         raise ValueError(f"Unsupported executor: {cluster_config.get('executor')}")

--- a/nemo_skills/pipeline/eval.py
+++ b/nemo_skills/pipeline/eval.py
@@ -68,7 +68,7 @@ class SupportedServers(str, Enum):
 @typer_unpacker
 def eval(
     ctx: typer.Context,
-    cluster: str = typer.Option(..., help="One of the configs inside ./cluster_configs or NEMO_SKILLS_CONFIGS"),
+    cluster: str = typer.Option(..., help="One of the configs inside ./cluster_configs or NEMO_SKILLS_CONFIG_DIR"),
     output_dir: str = typer.Option(..., help="Where to store evaluation results"),
     benchmarks: str = typer.Option(
         ...,

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -348,10 +348,6 @@ def get_mounts_from_config(cluster_config: dict, env_vars: dict = None):
     """
     mounts = cluster_config.get('mounts', [])
 
-    # if env_vars is None, we will get the env_vars from the cluster config
-    if env_vars is None:
-        env_vars = get_env_variables(cluster_config)
-
     # if there are env_mounts, we will add the mounts from the env_mounts
     for mount_id in range(len(mounts)):
         mount = mounts[mount_id]

--- a/nemo_skills/prompt/utils.py
+++ b/nemo_skills/prompt/utils.py
@@ -184,7 +184,7 @@ class Prompt:
         user = self.config.user.format(examples=examples, **input_dict)
         return user
 
-    def fill(self, input_dict: Dict[str, str], include_generation: bool = False) -> str | List[dict]:
+    def fill(self, input_dict: Dict[str, str], include_generation: bool = False, message_as_prompt: bool = False) -> str | List[dict]:
         """
         Fills the prompt with the input_dict.
         Operates in two modes:
@@ -194,6 +194,9 @@ class Prompt:
         Args:
             input_dict: The input dictionary to fill the prompt with.
             include_generation: Whether to include the generation in the prompt.
+            message_as_prompt: Whether to return the prompt as a single string or as a list of dictionaries.
+                If True, the prompt will be returned as a single string. If False, the prompt will be returned as a list
+                of dictionaries. Defaults to False.
 
         Returns:
             The filled prompt - either a string or a list of dictionaries.
@@ -220,6 +223,17 @@ class Prompt:
             ]
             if generation and include_generation:
                 messages.append({"role": "assistant", "content": generation})
+
+            if message_as_prompt:
+                # return the prompt as a single string
+                # if the first message (system) is empty, remove it
+                messages = [m["content"] for m in messages]
+
+                if messages[0] == "":
+                    messages = messages[1]
+                else:
+                    # join the messages with newlines
+                    messages = "\n\n".join(messages)
 
             return messages
 

--- a/nemo_skills/prompt/utils.py
+++ b/nemo_skills/prompt/utils.py
@@ -184,7 +184,9 @@ class Prompt:
         user = self.config.user.format(examples=examples, **input_dict)
         return user
 
-    def fill(self, input_dict: Dict[str, str], include_generation: bool = False, message_as_prompt: bool = False) -> str | List[dict]:
+    def fill(
+        self, input_dict: Dict[str, str], include_generation: bool = False, message_as_prompt: bool = False
+    ) -> str | List[dict]:
         """
         Fills the prompt with the input_dict.
         Operates in two modes:

--- a/nemo_skills/prompt/utils.py
+++ b/nemo_skills/prompt/utils.py
@@ -209,7 +209,7 @@ class Prompt:
             generation = ""
 
         if self.config.template:
-            prompt = Prompt.FORMAT.format(
+            prompt = self.FORMAT.format(
                 system=self.config.system,
                 user=self.build_user_message(input_dict),
                 generation=generation,


### PR DESCRIPTION
# Changelog
- Refactor the logic for cluster config resolution such that `NEMO_SKILLS_CONFIG` points to a yaml file full path that overrides all resolution logic
- Adds `NEMO_SKILLS_CONFIG_DIR` as the override for cluster_dir 
- Adds flag `message_as_prompt` which default to false for `Prompt.fill()` - this allows returning a squashed prompt for the messages for openai prompting.
- Make `create_remote_directory` accept list of filepaths to create multiple directories within same session
- Make `OpenAIModel` accept a list of strings same as others, which is then cast to a list of dicts with a single turn with role "user"
