### PR TITLE
Rewrite logic to get cluster config + update for getting slurm logs + remove caching

### DIFF
--- a/nemo_skills/pipeline/check_contamination.py
+++ b/nemo_skills/pipeline/check_contamination.py
@@ -44,7 +44,11 @@ def check_contamination(
     ctx: typer.Context,
     config_dir: str = typer.Option(None, help="Path to the cluster_configs dir"),
     log_dir: str = typer.Option(None, help="Can specify a custom location for slurm logs"),
-    cluster: str = typer.Option(..., help="One of the configs inside cluster_configs"),
+    cluster: str = typer.Option(
+        None,
+        help="One of the configs inside ./cluster_configs or NEMO_SKILLS_CONFIG_DIR. "
+        "Can also use NEMO_SKILLS_CONFIG instead of specifying as argument.",
+    ),
     input_file: str = typer.Option(
         ..., help="Input file with the data to check for contamination. An output of the retrieve_similar.py script."
     ),

--- a/nemo_skills/pipeline/check_contamination.py
+++ b/nemo_skills/pipeline/check_contamination.py
@@ -42,13 +42,13 @@ class SupportedServers(str, Enum):
 @typer_unpacker
 def check_contamination(
     ctx: typer.Context,
-    config_dir: str = typer.Option(None, help="Path to the cluster_configs dir"),
-    log_dir: str = typer.Option(None, help="Can specify a custom location for slurm logs"),
     cluster: str = typer.Option(
         None,
-        help="One of the configs inside ./cluster_configs or NEMO_SKILLS_CONFIG_DIR. "
+        help="One of the configs inside config_dir or NEMO_SKILLS_CONFIG_DIR or ./cluster_configs. "
         "Can also use NEMO_SKILLS_CONFIG instead of specifying as argument.",
     ),
+    config_dir: str = typer.Option(None, help="Can customize where we search for cluster configs"),
+    log_dir: str = typer.Option(None, help="Can specify a custom location for slurm logs"),
     input_file: str = typer.Option(
         ..., help="Input file with the data to check for contamination. An output of the retrieve_similar.py script."
     ),

--- a/nemo_skills/pipeline/convert.py
+++ b/nemo_skills/pipeline/convert.py
@@ -123,7 +123,11 @@ class SupportedDtypes(str, Enum):
 def convert(
     ctx: typer.Context,
     config_dir: str = typer.Option(None, help="Path to the cluster_configs dir"),
-    cluster: str = typer.Option(..., help="One of the configs inside cluster_configs"),
+    cluster: str = typer.Option(
+        None,
+        help="One of the configs inside ./cluster_configs or NEMO_SKILLS_CONFIG_DIR. "
+        "Can also use NEMO_SKILLS_CONFIG instead of specifying as argument.",
+    ),
     input_model: str = typer.Option(...),
     model_type: SupportedTypes = typer.Option("llama", help="Type of the model"),
     output_model: str = typer.Option(..., help="Where to put the final model"),

--- a/nemo_skills/pipeline/convert.py
+++ b/nemo_skills/pipeline/convert.py
@@ -122,12 +122,12 @@ class SupportedDtypes(str, Enum):
 @typer_unpacker
 def convert(
     ctx: typer.Context,
-    config_dir: str = typer.Option(None, help="Path to the cluster_configs dir"),
     cluster: str = typer.Option(
         None,
-        help="One of the configs inside ./cluster_configs or NEMO_SKILLS_CONFIG_DIR. "
+        help="One of the configs inside config_dir or NEMO_SKILLS_CONFIG_DIR or ./cluster_configs. "
         "Can also use NEMO_SKILLS_CONFIG instead of specifying as argument.",
     ),
+    config_dir: str = typer.Option(None, help="Can customize where we search for cluster configs"),
     input_model: str = typer.Option(...),
     model_type: SupportedTypes = typer.Option("llama", help="Type of the model"),
     output_model: str = typer.Option(..., help="Where to put the final model"),

--- a/nemo_skills/pipeline/eval.py
+++ b/nemo_skills/pipeline/eval.py
@@ -70,9 +70,10 @@ def eval(
     ctx: typer.Context,
     cluster: str = typer.Option(
         None,
-        help="One of the configs inside ./cluster_configs or NEMO_SKILLS_CONFIG_DIR. "
+        help="One of the configs inside config_dir or NEMO_SKILLS_CONFIG_DIR or ./cluster_configs. "
         "Can also use NEMO_SKILLS_CONFIG instead of specifying as argument.",
     ),
+    config_dir: str = typer.Option(None, help="Can customize where we search for cluster configs"),
     output_dir: str = typer.Option(..., help="Where to store evaluation results"),
     benchmarks: str = typer.Option(
         ...,
@@ -80,7 +81,6 @@ def eval(
         "Use <benchmark>:0 to only run greedy decoding. Has to be comma-separated "
         "if providing multiple benchmarks. E.g. gsm8k:4,human-eval:0",
     ),
-    config_dir: str = typer.Option(None, help="Can customize where we search for cluster configs"),
     expname: str = typer.Option("eval", help="Name of the experiment"),
     model: str = typer.Option(None, help="Path to the model to be evaluated"),
     server_address: str = typer.Option(None, help="Address of the server hosting the model"),

--- a/nemo_skills/pipeline/eval.py
+++ b/nemo_skills/pipeline/eval.py
@@ -68,7 +68,11 @@ class SupportedServers(str, Enum):
 @typer_unpacker
 def eval(
     ctx: typer.Context,
-    cluster: str = typer.Option(..., help="One of the configs inside ./cluster_configs or NEMO_SKILLS_CONFIG_DIR"),
+    cluster: str = typer.Option(
+        None,
+        help="One of the configs inside ./cluster_configs or NEMO_SKILLS_CONFIG_DIR. "
+        "Can also use NEMO_SKILLS_CONFIG instead of specifying as argument.",
+    ),
     output_dir: str = typer.Option(..., help="Where to store evaluation results"),
     benchmarks: str = typer.Option(
         ...,

--- a/nemo_skills/pipeline/generate.py
+++ b/nemo_skills/pipeline/generate.py
@@ -59,12 +59,12 @@ def get_cmd(output_dir, extra_arguments, random_seed=None, eval_args=None):
 @typer_unpacker
 def generate(
     ctx: typer.Context,
-    config_dir: str = typer.Option(None, help="Path to the cluster_configs dir"),
     cluster: str = typer.Option(
         None,
-        help="One of the configs inside ./cluster_configs or NEMO_SKILLS_CONFIG_DIR. "
+        help="One of the configs inside config_dir or NEMO_SKILLS_CONFIG_DIR or ./cluster_configs. "
         "Can also use NEMO_SKILLS_CONFIG instead of specifying as argument.",
     ),
+    config_dir: str = typer.Option(None, help="Can customize where we search for cluster configs"),
     output_dir: str = typer.Option(..., help="Where to put results"),
     expname: str = typer.Option("generate", help="Nemo run experiment name"),
     model: str = typer.Option(None, help="Path to the model or model name in API"),

--- a/nemo_skills/pipeline/generate.py
+++ b/nemo_skills/pipeline/generate.py
@@ -60,7 +60,11 @@ def get_cmd(output_dir, extra_arguments, random_seed=None, eval_args=None):
 def generate(
     ctx: typer.Context,
     config_dir: str = typer.Option(None, help="Path to the cluster_configs dir"),
-    cluster: str = typer.Option(..., help="One of the configs inside cluster_configs"),
+    cluster: str = typer.Option(
+        None,
+        help="One of the configs inside ./cluster_configs or NEMO_SKILLS_CONFIG_DIR. "
+        "Can also use NEMO_SKILLS_CONFIG instead of specifying as argument.",
+    ),
     output_dir: str = typer.Option(..., help="Where to put results"),
     expname: str = typer.Option("generate", help="Nemo run experiment name"),
     model: str = typer.Option(None, help="Path to the model or model name in API"),

--- a/nemo_skills/pipeline/llm_math_judge.py
+++ b/nemo_skills/pipeline/llm_math_judge.py
@@ -43,14 +43,14 @@ def llm_math_judge(
     ctx: typer.Context,
     cluster: str = typer.Option(
         None,
-        help="One of the configs inside ./cluster_configs or NEMO_SKILLS_CONFIG_DIR. "
+        help="One of the configs inside config_dir or NEMO_SKILLS_CONFIG_DIR or ./cluster_configs. "
         "Can also use NEMO_SKILLS_CONFIG instead of specifying as argument.",
     ),
+    config_dir: str = typer.Option(None, help="Can customize where we search for cluster configs"),
     input_files: List[str] = typer.Option(
         ...,
         help="Can also specify multiple glob patterns, like output-rs*.jsonl. Will add judgement field to each file",
     ),
-    config_dir: str = typer.Option(None, help="Path to the cluster_configs dir"),
     log_dir: str = typer.Option(None, help="Can specify a custom location for slurm logs"),
     expname: str = typer.Option("llm-math-judge", help="Nemo run experiment name"),
     model: str = typer.Option(None, help="Path to the model or model name in API"),

--- a/nemo_skills/pipeline/llm_math_judge.py
+++ b/nemo_skills/pipeline/llm_math_judge.py
@@ -41,7 +41,11 @@ def get_judge_cmd(input_files, extra_arguments=""):
 @typer_unpacker
 def llm_math_judge(
     ctx: typer.Context,
-    cluster: str = typer.Option(..., help="One of the configs inside ./cluster_configs or NEMO_SKILLS_CONFIGS"),
+    cluster: str = typer.Option(
+        None,
+        help="One of the configs inside ./cluster_configs or NEMO_SKILLS_CONFIG_DIR. "
+        "Can also use NEMO_SKILLS_CONFIG instead of specifying as argument.",
+    ),
     input_files: List[str] = typer.Option(
         ...,
         help="Can also specify multiple glob patterns, like output-rs*.jsonl. Will add judgement field to each file",

--- a/nemo_skills/pipeline/start_server.py
+++ b/nemo_skills/pipeline/start_server.py
@@ -66,7 +66,7 @@ def start_server(
         add_task(
             exp,
             cmd="",  # not running anything except the server
-            task_name=f'server-{model.replace("/", "-")}',
+            task_name='server',
             log_dir=log_dir,
             container=cluster_config["containers"]["nemo-skills"],
             cluster_config=cluster_config,
@@ -77,7 +77,6 @@ def start_server(
         # we don't want to detach in this case even on slurm, so not using run_exp
         exp.run(detach=False, tail_logs=True)
         # TODO: seems like not being killed? If nemorun doesn't do this, we can catch the signal and kill the server ourselves
-        # TODO: logs not streamed, probably a bug with custom log path
 
 
 if __name__ == "__main__":

--- a/nemo_skills/pipeline/start_server.py
+++ b/nemo_skills/pipeline/start_server.py
@@ -32,15 +32,15 @@ class SupportedServers(str, Enum):
 def start_server(
     cluster: str = typer.Option(
         None,
-        help="One of the configs inside ./cluster_configs or NEMO_SKILLS_CONFIG_DIR. "
+        help="One of the configs inside config_dir or NEMO_SKILLS_CONFIG_DIR or ./cluster_configs. "
         "Can also use NEMO_SKILLS_CONFIG instead of specifying as argument.",
     ),
+    config_dir: str = typer.Option(None, help="Can customize where we search for cluster configs"),
     model: str = typer.Option(..., help="Path to the model"),
     server_type: SupportedServers = typer.Option('trtllm', help="Type of server to use"),
     server_gpus: int = typer.Option(..., help="Number of GPUs to use for hosting the model"),
     server_nodes: int = typer.Option(1, help="Number of nodes to use for hosting the model"),
     server_args: str = typer.Option("", help="Additional arguments for the server"),
-    config_dir: str = typer.Option(None, help="Path to the cluster_configs dir"),
     log_dir: str = typer.Option(None, help="Custom location for slurm logs"),
     partition: str = typer.Option(None, help="Cluster partition to use"),
     with_sandbox: bool = typer.Option(False, help="Enables local sandbox if code execution is required"),

--- a/nemo_skills/pipeline/start_server.py
+++ b/nemo_skills/pipeline/start_server.py
@@ -30,7 +30,11 @@ class SupportedServers(str, Enum):
 @app.command()
 @typer_unpacker
 def start_server(
-    cluster: str = typer.Option(..., help="One of the configs inside cluster_configs"),
+    cluster: str = typer.Option(
+        None,
+        help="One of the configs inside ./cluster_configs or NEMO_SKILLS_CONFIG_DIR. "
+        "Can also use NEMO_SKILLS_CONFIG instead of specifying as argument.",
+    ),
     model: str = typer.Option(..., help="Path to the model"),
     server_type: SupportedServers = typer.Option('trtllm', help="Type of server to use"),
     server_gpus: int = typer.Option(..., help="Number of GPUs to use for hosting the model"),

--- a/nemo_skills/pipeline/summarize_results.py
+++ b/nemo_skills/pipeline/summarize_results.py
@@ -38,10 +38,11 @@ def summarize_results(
         help="Path to the dir with results. Needs to contain <benchmark> dirs inside. "
         "If cluster is specified, will fetch the results from there.",
     ),
-    cluster: Optional[str] = typer.Option(
+    cluster: str = typer.Option(
         None,
-        help="Cluster configuration to take results from. If 'local' is explicitly specified, "
-        "we assume the location is relative to one of the mounted dirs.",
+        help="One of the configs inside ./cluster_configs or NEMO_SKILLS_CONFIG_DIR. "
+        "Can also use NEMO_SKILLS_CONFIG instead of specifying as argument. "
+        "If not specified, will assume the results are in the local filesystem.",
     ),
     config_dir: Optional[str] = typer.Option(None, help="Path to the cluster_configs dir."),
     benchmarks: Optional[str] = typer.Option(
@@ -53,6 +54,8 @@ def summarize_results(
 ):
     """Summarize results of an evaluation job."""
     setup_logging(disable_hydra_logs=False, log_level=logging.INFO if not debug else logging.DEBUG)
+
+    cluster = cluster or os.environ.get("NEMO_SKILLS_CONFIG")
 
     # copying results from the cluster if necessary
     if cluster is not None:

--- a/nemo_skills/pipeline/summarize_results.py
+++ b/nemo_skills/pipeline/summarize_results.py
@@ -40,11 +40,11 @@ def summarize_results(
     ),
     cluster: str = typer.Option(
         None,
-        help="One of the configs inside ./cluster_configs or NEMO_SKILLS_CONFIG_DIR. "
+        help="One of the configs inside config_dir or NEMO_SKILLS_CONFIG_DIR or ./cluster_configs. "
         "Can also use NEMO_SKILLS_CONFIG instead of specifying as argument. "
         "If not specified, will assume the results are in the local filesystem.",
     ),
-    config_dir: Optional[str] = typer.Option(None, help="Path to the cluster_configs dir."),
+    config_dir: str = typer.Option(None, help="Can customize where we search for cluster configs"),
     benchmarks: Optional[str] = typer.Option(
         None,
         help="Specify benchmarks to run (comma separated). "

--- a/nemo_skills/pipeline/train.py
+++ b/nemo_skills/pipeline/train.py
@@ -140,7 +140,11 @@ def get_avg_checkpoints_cmd(nemo_model, output_dir, final_nemo_path, average_ste
 def train(
     ctx: typer.Context,
     config_dir: str = typer.Option(None, help="Path to the cluster_configs dir"),
-    cluster: str = typer.Option(..., help="One of the configs inside cluster_configs"),
+    cluster: str = typer.Option(
+        None,
+        help="One of the configs inside ./cluster_configs or NEMO_SKILLS_CONFIG_DIR. "
+        "Can also use NEMO_SKILLS_CONFIG instead of specifying as argument.",
+    ),
     output_dir: str = typer.Option(..., help="Where to put results"),
     final_nemo_path: str = typer.Option(None, help="Where to put the final checkpoint"),
     expname: str = typer.Option(..., help="Experiment name"),

--- a/nemo_skills/pipeline/train.py
+++ b/nemo_skills/pipeline/train.py
@@ -139,12 +139,12 @@ def get_avg_checkpoints_cmd(nemo_model, output_dir, final_nemo_path, average_ste
 @typer_unpacker
 def train(
     ctx: typer.Context,
-    config_dir: str = typer.Option(None, help="Path to the cluster_configs dir"),
     cluster: str = typer.Option(
         None,
-        help="One of the configs inside ./cluster_configs or NEMO_SKILLS_CONFIG_DIR. "
+        help="One of the configs inside config_dir or NEMO_SKILLS_CONFIG_DIR or ./cluster_configs. "
         "Can also use NEMO_SKILLS_CONFIG instead of specifying as argument.",
     ),
+    config_dir: str = typer.Option(None, help="Can customize where we search for cluster configs"),
     output_dir: str = typer.Option(..., help="Where to put results"),
     final_nemo_path: str = typer.Option(None, help="Where to put the final checkpoint"),
     expname: str = typer.Option(..., help="Experiment name"),

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -186,22 +186,23 @@ class hashabledict(dict):
         return hash(frozenset(self))
 
 
-def get_cluster_config(cluster, config_dir=None):
+def get_cluster_config(cluster=None, config_dir=None):
     """Trying to find an appropriate cluster config.
 
     Will search in the following order:
-    1. NEMO_SKILLS_CONFIG_DIR environment variable
-    2. config_dir parameter
+    1. config_dir parameter
+    2. NEMO_SKILLS_CONFIG_DIR environment variable
     3. Current folder / cluster_configs
     4. This file folder / ../../cluster_configs
 
-    If NEMO_SKILLS_CONFIG is provided, it will be used as a full path to the config file
+    If NEMO_SKILLS_CONFIG is provided and cluster is None,
+    it will be used as a full path to the config file
     and NEMO_SKILLS_CONFIG_DIR will be ignored.
     """
     config_file = None
 
     # First check if NEMO_SKILLS_CONFIG is provided as a full path
-    if 'NEMO_SKILLS_CONFIG' in os.environ:
+    if cluster is None and 'NEMO_SKILLS_CONFIG' in os.environ:
         config_file = Path(os.environ['NEMO_SKILLS_CONFIG'])
         config_dir = config_file.parent
 

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -19,7 +19,6 @@ import shlex
 import subprocess
 import tarfile
 from dataclasses import dataclass
-from functools import lru_cache
 from pathlib import Path
 
 import nemo_run as run
@@ -180,10 +179,11 @@ class CustomJobDetails(SlurmJobDetails):
         return os.path.join(self.folder, "*_srun.log")
 
 
-# a very hacky way to cache cluster config - is there a better way to do this?
-class hashabledict(dict):
-    def __hash__(self):
-        return hash(frozenset(self))
+def read_config(config_file):
+    with open(config_file, "rt", encoding="utf-8") as fin:
+        cluster_config = yaml.safe_load(fin)
+
+    return cluster_config
 
 
 def get_cluster_config(cluster=None, config_dir=None):
@@ -199,39 +199,32 @@ def get_cluster_config(cluster=None, config_dir=None):
     it will be used as a full path to the config file
     and NEMO_SKILLS_CONFIG_DIR will be ignored.
     """
-    config_file = None
+    # if cluster is provided, we try to find it in one of the folders
+    if cluster is not None:
+        # either using the provided config_dir or getting from env var
+        config_dir = config_dir or os.environ.get("NEMO_SKILLS_CONFIG_DIR")
+        if config_dir:
+            return read_config(Path(config_dir) / f"{cluster}.yaml")
 
-    # First check if NEMO_SKILLS_CONFIG is provided as a full path
-    if cluster is None and 'NEMO_SKILLS_CONFIG' in os.environ:
-        config_file = Path(os.environ['NEMO_SKILLS_CONFIG'])
-        config_dir = config_file.parent
+        # if it's not defined we are trying to find locally
+        if (Path.cwd() / 'cluster_configs' / f"{cluster}.yaml").exists():
+            return read_config(Path.cwd() / 'cluster_configs' / f"{cluster}.yaml")
 
-    # Then check if NEMO_SKILLS_CONFIG_DIR is provided
-    elif 'NEMO_SKILLS_CONFIG_DIR' in os.environ:
-        config_dir = Path(os.environ['NEMO_SKILLS_CONFIG_DIR'])
+        if (Path(__file__).parents[2] / 'cluster_configs' / f"{cluster}.yaml").exists():
+            return read_config(Path(__file__).parents[2] / 'cluster_configs' / f"{cluster}.yaml")
 
-    # If config_dir was provided, or one of the above env variables was set
-    if config_dir is not None:
-        config_dir = Path(str(config_dir))
-    else:
-        # If no config_dir was provided, we will try to find the config in the current or parent folder
-        if (Path.cwd() / 'cluster_configs').is_dir():
-            config_dir = Path.cwd() / 'cluster_configs'
-        else:
-            config_dir = Path(__file__).parents[2] / 'cluster_configs'
+        raise ValueError(f"Cluster config {cluster} not found in any of the supported folders.")
 
-    # If config_file is not already resolved, concatenate the config_dir with the cluster name
-    if config_file is None:
-        config_file = config_dir / f'{cluster}.yaml'
+    config_file = os.environ.get("NEMO_SKILLS_CONFIG")
+    if not config_file:
+        raise ValueError("Either cluster or NEMO_SKILLS_CONFIG must be provided.")
 
-    # Read the config
-    with open(str(config_file), "rt", encoding="utf-8") as fin:
-        cluster_config = yaml.safe_load(fin)
+    if not Path(config_file).exists():
+        raise ValueError(f"Cluster config {config_file} not found.")
 
-    return hashabledict(cluster_config)
+    return read_config(config_file)
 
 
-@lru_cache
 def get_tunnel(cluster_config):
     return run.SSHTunnel(**cluster_config["ssh_tunnel"])
 
@@ -262,7 +255,6 @@ def cluster_download(tunnel, remote_dir, local_dir):
     os.remove(local_tar)
 
 
-@lru_cache
 def get_packager():
     """Will check if we are running from a git repo and use git packager or default packager otherwise."""
     try:
@@ -396,7 +388,6 @@ def get_mounts_from_config(cluster_config: dict, env_vars: dict = None):
     return mounts
 
 
-@lru_cache
 def get_executor(
     cluster_config,
     container,

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -170,6 +170,15 @@ class CustomJobDetails(SlurmJobDetails):
     def srun_stderr(self) -> Path:
         return Path(self.folder) / f"{self.log_prefix}_srun.log"
 
+    @property
+    def ls_term(self) -> str:
+        """This term will be used to fetch the logs.
+
+        The command used to list the files is ls -1 {ls_term} 2> /dev/null
+        """
+        assert self.folder
+        return os.path.join(self.folder, "*_srun.log")
+
 
 # a very hacky way to cache cluster config - is there a better way to do this?
 class hashabledict(dict):


### PR DESCRIPTION
The slurm logs logic is to enable nemo run commands for getting the logs. Will work after https://github.com/NVIDIA/NeMo-Run/pull/69 is merged (but doesn't break anything, so we don't need to wait for that PR)