### PR TITLE
Allow for other servers to use openai api

### DIFF
--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -21,6 +21,7 @@ from dataclasses import asdict, field
 from pathlib import Path
 
 import hydra
+from omegaconf import open_dict
 from tqdm import tqdm
 
 from nemo_skills.code_execution.sandbox import get_sandbox, sandbox_params
@@ -130,9 +131,9 @@ def generate(cfg: GenerateSolutionsConfig):
     if cfg.prompt_template is None:
         # TODO: handle this explicitly in model.py clients
         # switching to OpenAI client always if prompt template is not provided
-        cfg.server.server_type = "openai"
-        cfg.server.base_url = f"{cfg.server.host}:{cfg.server.port}/v1"
-        cfg.server.model = "model"
+        with open_dict(cfg.server):
+            cfg.server["server_type"] = "openai"
+            cfg.server["model"] = "model"
         if cfg.code_execution:
             raise ValueError("Code execution is not supported for OpenAI server")
 

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -128,7 +128,7 @@ def generate(cfg: GenerateSolutionsConfig):
 
     LOG.info("Config used: %s", cfg)
 
-    if cfg.prompt_template is None:
+    if cfg.prompt_template is None and cfg.server["server_type"] != "openai":
         # TODO: handle this explicitly in model.py clients
         # switching to OpenAI client always if prompt template is not provided
         with open_dict(cfg.server):

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -131,6 +131,8 @@ def generate(cfg: GenerateSolutionsConfig):
         # TODO: handle this explicitly in model.py clients
         # switching to OpenAI client always if prompt template is not provided
         cfg.server.server_type = "openai"
+        cfg.server.base_url = "127.0.0.1:5000/v1"
+        cfg.server.model = "model"
         if cfg.code_execution:
             raise ValueError("Code execution is not supported for OpenAI server")
 

--- a/nemo_skills/inference/generate.py
+++ b/nemo_skills/inference/generate.py
@@ -131,7 +131,7 @@ def generate(cfg: GenerateSolutionsConfig):
         # TODO: handle this explicitly in model.py clients
         # switching to OpenAI client always if prompt template is not provided
         cfg.server.server_type = "openai"
-        cfg.server.base_url = "127.0.0.1:5000/v1"
+        cfg.server.base_url = f"{cfg.server.host}:{cfg.server.port}/v1"
         cfg.server.model = "model"
         if cfg.code_execution:
             raise ValueError("Code execution is not supported for OpenAI server")

--- a/nemo_skills/inference/server/model.py
+++ b/nemo_skills/inference/server/model.py
@@ -256,7 +256,7 @@ class OpenAIModel(BaseModel):
                 api_key = os.getenv("NVIDIA_API_KEY", api_key)
                 if not api_key:
                     raise ValueError("NVIDIA_API_KEY is required for Nvidia-hosted models.")
-            else:
+            elif base_url is not None and 'api.openai.com' in base_url:
                 api_key = os.getenv("OPENAI_API_KEY", api_key)
                 if not api_key:
                     raise ValueError("OPENAI_API_KEY is required for OpenAI models.")

--- a/nemo_skills/inference/server/model.py
+++ b/nemo_skills/inference/server/model.py
@@ -239,7 +239,7 @@ class OpenAIModel(BaseModel):
         model=None,
         base_url=None,
         api_key=None,
-        max_parallel_requests: int = 100,  # can adjust to avoid rate-limiting
+        max_parallel_requests: int = 1000,  # can adjust to avoid rate-limiting
         **kwargs,
     ):
         super().__init__(**kwargs)

--- a/nemo_skills/inference/server/model.py
+++ b/nemo_skills/inference/server/model.py
@@ -234,6 +234,8 @@ class NemoModel(BaseModel):
 class OpenAIModel(BaseModel):
     def __init__(
         self,
+        host: str = '127.0.0.1',
+        port: str = '5000',
         model=None,
         base_url=None,
         api_key=None,
@@ -249,7 +251,8 @@ class OpenAIModel(BaseModel):
                 raise ValueError("model argument is required for OpenAI model.")
 
         if base_url is None:
-            base_url = os.getenv("NEMO_SKILLS_OPENAI_BASE_URL")
+            # if not provided, we assume it's served on host/port
+            base_url = os.getenv("NEMO_SKILLS_OPENAI_BASE_URL", f"http://{host}:{port}/v1")
 
         if api_key is None:
             if base_url is not None and 'api.nvidia.com' in base_url:


### PR DESCRIPTION
This needs to be done differently (inside the client), but for now this workaround should work to unblock nemo-oai integration