### PR TITLE
Updating docs with length-based question filtering updates

### DIFF
--- a/docs/openmathinstruct2/dataset.md
+++ b/docs/openmathinstruct2/dataset.md
@@ -254,7 +254,7 @@ update_output_files("<path to workspace>/new-problems-solution-augmentation/", c
 
 Now all the data is generated and you can follow up by converting it to the SFT format.
 We remove the problems marked as contaminated.
-We also remove solutions with length > 1024 Llama tokens.
+We also remove problems and solutions with length > 1024 Llama tokens. 
 To avoid the models from generating extremely short solutions, we remove solutions shorter than 200 characters.
 
 ```bash
@@ -264,6 +264,8 @@ python -m nemo_skills.training.prepare_sft_data \
     ++input_files="<path to workspace>/solution-augmentation/**/output-rs*.jsonl <path to workspace>/new-problems-solution-augmentation/**/output-rs*.jsonl" \
     ++output_path=<path to workspace>/sft_data.jsonl \
     ++filters.remove_contamindated=true \
+    ++filters.remove_len_outlier_problems=true \
+    ++max_problem_length=1024 \
     ++filters.remove_len_outlier_solutions=true \
     ++use_chars_for_min_length=true \
     ++min_solution_length=200 \

--- a/docs/openmathinstruct2/training.md
+++ b/docs/openmathinstruct2/training.md
@@ -83,7 +83,7 @@ ns train \
     --num_gpus=8 \
     --average_steps=10000,20000,30000,40000,50000,60000 \
     --training_data=/workspace/openmathinstruct2-sft.jsonl \
-    ++model.data.train_ds.micro_batch_size=4 \
+    ++model.data.train_ds.micro_batch_size=8 \
     ++model.tensor_model_parallel_size=4 \
     ++model.pipeline_model_parallel_size=1 \
     ++model.optim.lr=2e-5 \


### PR DESCRIPTION
Recently in a (github issue)[https://github.com/Kipok/NeMo-Skills/issues/214], a discussion about length-based filtering for questions came up. We had originally not done any such filtering for OpenMathInstruct-2, but found that doing such filtering doesn't affect the performance, and allows for a higher micro batch size. This PR updates the docs with this finding.  