### PR TITLE
Avoid the streaming compression route if the command  is not available

### DIFF
--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -296,8 +296,16 @@ def cluster_download(tunnel: SSHTunnel, remote_dir: str, local_dir: str, remote_
     result = tunnel.run(f'du -sb {remote_dir} | cut -f1')
     total_size = int(result.stdout.strip())
     
-    # Certain systems may not have the `pv` command
-    streaming_possible = (shutil.which("pv") is not None)
+    # Check if result directory compression is streamable
+    streaming_possible = False
+    try:
+        # Check whether the command pv is present on the remote system or not.
+        # Certain systems may not have the `pv` command
+        result = tunnel.run('which pv', warn=True)
+        streaming_possible = (result.exited == 0)
+    except Exception:
+        streaming_possible = False
+
     if streaming_possible:
         # We can do streaming compression 
         # Command for streaming the compression progress

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -295,14 +295,14 @@ def cluster_download(tunnel: SSHTunnel, remote_dir: str, local_dir: str, remote_
     # Get the directory size
     result = tunnel.run(f'du -sb {remote_dir} | cut -f1')
     total_size = int(result.stdout.strip())
-    
+
     # Check if result directory compression is streamable
     streaming_possible = False
     try:
         # Check whether the command pv is present on the remote system or not.
         # Certain systems may not have the `pv` command
         result = tunnel.run('which pv', warn=True)
-        streaming_possible = (result.exited == 0)
+        streaming_possible = result.exited == 0
     except Exception:
         streaming_possible = False
 

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -16,6 +16,7 @@ import json
 import logging
 import os
 import shlex
+import shutil
 import subprocess
 import sys
 import tarfile
@@ -294,16 +295,23 @@ def cluster_download(tunnel: SSHTunnel, remote_dir: str, local_dir: str, remote_
     # Get the directory size
     result = tunnel.run(f'du -sb {remote_dir} | cut -f1')
     total_size = int(result.stdout.strip())
-    # Command for streaming the compression progress
-    command = (
-        f'cd {remote_dir_parent} && '
-        f'tar -cf - {remote_dir_name} | '
-        f'pv -s {total_size} -p -t -e -b -F "Compressing Remote Directory: %b %t %p" | '
-        f'gzip > {remote_tar}'
-    )
-
-    # Run the remote compression command and stream the progress
-    result = tunnel.run(command, watchers=[OutputWatcher()], pty=True, hide=False)
+    
+    # Certain systems may not have the `pv` command
+    streaming_possible = (shutil.which("pv") is not None)
+    if streaming_possible:
+        # We can do streaming compression 
+        # Command for streaming the compression progress
+        command = (
+            f'cd {remote_dir_parent} && '
+            f'tar -cf - {remote_dir_name} | '
+            f'pv -s {total_size} -p -t -e -b -F "Compressing Remote Directory: %b %t %p" | '
+            f'gzip > {remote_tar}'
+        )
+        # Run the remote compression command and stream the progress
+        result = tunnel.run(command, watchers=[OutputWatcher()], pty=True, hide=False)
+    else:
+        command = f'cd {remote_dir_parent} && tar -czf {remote_tar} {remote_dir_name}'
+        result = tunnel.run(command, hide=False)
 
     # Get SFTP client from tunnel's session's underlying client
     sftp = tunnel.session.client.open_sftp()


### PR DESCRIPTION
The `pv` utility may not be available on certain systems. This patch checks for whether the utility is available or not, and avoids the streaming compression version when it is not available. 