### PR TITLE
Remove RLIMIT_STACK in sandbox

### DIFF
--- a/nemo_skills/code_execution/local_sandbox/local_sandbox_server.py
+++ b/nemo_skills/code_execution/local_sandbox/local_sandbox_server.py
@@ -84,7 +84,6 @@ def execute_code_subprocess(generated_code, queue):
     limit = 1024 * 1024 * 1024 * 10  # 10gb - somehow with a smaller limit the server dies when numpy is used
     resource.setrlimit(resource.RLIMIT_AS, (limit, limit))
     resource.setrlimit(resource.RLIMIT_DATA, (limit, limit))
-    # resource.setrlimit(resource.RLIMIT_STACK, (limit, limit))
 
     # this can be overriden inside generated code, so it's not a guaranteed protection
     sys.stdout = StringIO()

--- a/nemo_skills/code_execution/local_sandbox/local_sandbox_server.py
+++ b/nemo_skills/code_execution/local_sandbox/local_sandbox_server.py
@@ -84,7 +84,7 @@ def execute_code_subprocess(generated_code, queue):
     limit = 1024 * 1024 * 1024 * 10  # 10gb - somehow with a smaller limit the server dies when numpy is used
     resource.setrlimit(resource.RLIMIT_AS, (limit, limit))
     resource.setrlimit(resource.RLIMIT_DATA, (limit, limit))
-    resource.setrlimit(resource.RLIMIT_STACK, (limit, limit))
+    # resource.setrlimit(resource.RLIMIT_STACK, (limit, limit))
 
     # this can be overriden inside generated code, so it's not a guaranteed protection
     sys.stdout = StringIO()


### PR DESCRIPTION
### Reason for Removing `resource.setrlimit(resource.RLIMIT_STACK)`

**Problem Description**: 
The execution environment is encountering a `ValueError` with the message `not allowed to raise maximum limit` when attempting to set the stack size limit using `resource.setrlimit(resource.RLIMIT_STACK, (limit, limit))`. This error occurs because the Python process lacks the necessary permissions to increase its stack limit beyond the system-imposed maximum.

**Solution**:
- By removing this line, we avoid unnecessary and potentially problematic attempts to modify the stack size limit. The system default or the existing limit will remain in place, which should suffice for the safe execution of the intended operations.

**Impact of Change**:
- Removing this line has shown to resolve the error without observable negative impact on memory management or program stability in the environments where this issue was encountered.
- It maintains the intention of memory constraints through the other limits (`RLIMIT_AS` and `RLIMIT_DATA`) which do not trigger permissions issues.

This change should improve compatibility across different environments, especially where permission to raise stack limits is restricted. 
