### PR TITLE
Add generic script processing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,4 +38,4 @@ jobs:
         export NEMO_SKILLS_SANDBOX_HOST=`docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' local-sandbox`
         set -o pipefail # this will make sure next line returns non-0 exit code if tests fail
         python -m nemo_skills.dataset.prepare
-        python -m pytest tests/ -m "not gpu" --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=nemo_skills --cov=pipeline --durations=30 -rs -vvv | tee pytest-coverage.txt
+        python -m pytest tests/ -m "not gpu" --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=nemo_skills --cov=pipeline --durations=30 -rs -s -vvv

--- a/nemo_skills/pipeline/cli.py
+++ b/nemo_skills/pipeline/cli.py
@@ -23,7 +23,7 @@ from nemo_skills.pipeline.convert import convert
 from nemo_skills.pipeline.eval import eval
 from nemo_skills.pipeline.generate import generate
 from nemo_skills.pipeline.llm_math_judge import llm_math_judge
-from nemo_skills.pipeline.script import script
+from nemo_skills.pipeline.run_cmd import run_cmd
 from nemo_skills.pipeline.start_server import start_server
 from nemo_skills.pipeline.summarize_results import summarize_results
 from nemo_skills.pipeline.train import train

--- a/nemo_skills/pipeline/cli.py
+++ b/nemo_skills/pipeline/cli.py
@@ -23,6 +23,7 @@ from nemo_skills.pipeline.convert import convert
 from nemo_skills.pipeline.eval import eval
 from nemo_skills.pipeline.generate import generate
 from nemo_skills.pipeline.llm_math_judge import llm_math_judge
+from nemo_skills.pipeline.script import script
 from nemo_skills.pipeline.start_server import start_server
 from nemo_skills.pipeline.summarize_results import summarize_results
 from nemo_skills.pipeline.train import train

--- a/nemo_skills/pipeline/run_cmd.py
+++ b/nemo_skills/pipeline/run_cmd.py
@@ -42,7 +42,7 @@ def get_cmd(module, script, extra_arguments):
 
 @app.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
 @typer_unpacker
-def script(
+def run_cmd(
     ctx: typer.Context,
     cluster: str = typer.Option(
         None,

--- a/nemo_skills/pipeline/run_cmd.py
+++ b/nemo_skills/pipeline/run_cmd.py
@@ -68,7 +68,7 @@ def run_cmd(
             "from the current working directory should be provided."
         ),
     ),
-    num_gpus: int = typer.Option(1, help="Number of GPUs to use"),
+    num_gpus: int | None = typer.Option(None, help="Number of GPUs to use"),
     run_after: str = typer.Option(
         None, help="Can specify an expname that needs to be completed before this one starts"
     ),

--- a/nemo_skills/pipeline/script.py
+++ b/nemo_skills/pipeline/script.py
@@ -27,8 +27,7 @@ LOG = logging.getLogger(__file__)
 
 
 def get_cmd(module, extra_arguments):
-    cmd = "pip install transformers && "
-    cmd += f"time python -m {module} "
+    cmd = f"python -m {module} "
     cmd += f" {extra_arguments} "
     cmd = (
         f"export PYTHONPATH=$PYTHONPATH:/nemo_run/code && "

--- a/nemo_skills/pipeline/script.py
+++ b/nemo_skills/pipeline/script.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import os
 from pathlib import Path
 
 import nemo_run as run

--- a/nemo_skills/pipeline/script.py
+++ b/nemo_skills/pipeline/script.py
@@ -67,9 +67,9 @@ def script(
     script: str = typer.Option(
         None,
         help=(
-            "Path to the python script to run. "
-            "If specified, will run this script instead of the module. "
-            "Will be passed as the first argument to the module."
+            "Path to the python script to run. The script must in the git index "
+            "of the directory where this command is run. The relative path to the script "
+            "from the current working directory should be provided."
         ),
     ),
     num_gpus: int = typer.Option(1, help="Number of GPUs to use"),

--- a/nemo_skills/pipeline/script.py
+++ b/nemo_skills/pipeline/script.py
@@ -26,15 +26,19 @@ from nemo_skills.utils import setup_logging
 LOG = logging.getLogger(__file__)
 
 
-def get_cmd(module, extra_arguments):
-    cmd = f"python -m {module} "
+def get_cmd(module, script, extra_arguments):
+    if module is not None and script is not None:
+        raise ValueError("Cannot specify both --module and --script")
+
+    if module is None:
+        cmd = f"python /nemo_run/code/{script} "
+    else:
+        cmd = f"python -m {module} "
+
     cmd += f" {extra_arguments} "
     cmd = (
         f"export PYTHONPATH=$PYTHONPATH:/nemo_run/code && "
         f"cd /nemo_run/code && "
-        # might be required if we are not hosting server ourselves
-        f"export NVIDIA_API_KEY={os.getenv('NVIDIA_API_KEY', '')} && "
-        f"export OPENAI_API_KEY={os.getenv('OPENAI_API_KEY', '')} && "
         f"{cmd}"
     )
     return cmd
@@ -54,10 +58,19 @@ def script(
         None, help="Can specify if need interactive jobs or a specific non-default partition"
     ),
     module: str = typer.Option(
+        None,
         help=(
             "Searches sys.path in the NeMo-Skills Container for the named module and runs the "
             "corresponding .py file as a script."
         )
+    ),
+    script: str = typer.Option(
+        None,
+        help=(
+            "Path to the python script to run. "
+            "If specified, will run this script instead of the module. "
+            "Will be passed as the first argument to the module."
+        ),
     ),
     num_gpus: int = typer.Option(1, help="Number of GPUs to use"),
     run_after: str = typer.Option(
@@ -66,10 +79,8 @@ def script(
     config_dir: str = typer.Option(None, help="Can customize where we search for cluster configs"),
     log_dir: str = typer.Option(help="Specify a custom location for slurm logs. "),
 ):
-    """Generate LLM completions for a given input file.
+    """Run a pre-defined module or script in the NeMo-Skills container.
 
-    Run `python -m nemo_skills.inference.generate --help` for other supported arguments
-    (need to be prefixed with ++, since we use Hydra for that script).
     """
     setup_logging(disable_hydra_logs=False)
     extra_arguments = f'{" ".join(ctx.args)}'
@@ -78,9 +89,9 @@ def script(
     check_if_mounted(cluster_config, log_dir)
 
     with run.Experiment(expname) as exp:
-        _ = add_task(
+        add_task(
             exp,
-            cmd=get_cmd(module=module, extra_arguments=extra_arguments),
+            cmd=get_cmd(module=module, script=script, extra_arguments=extra_arguments),
             task_name="script",
             log_dir=log_dir,
             container=cluster_config["containers"]["nemo-skills"],

--- a/nemo_skills/pipeline/script.py
+++ b/nemo_skills/pipeline/script.py
@@ -63,7 +63,7 @@ def script(
         None, help="Can specify an expname that needs to be completed before this one starts"
     ),
     config_dir: str = typer.Option(None, help="Can customize where we search for cluster configs"),
-    log_dir: str = typer.Option(None, help="Can specify a custom location for slurm logs. "),
+    log_dir: str = typer.Option(help="Specify a custom location for slurm logs. "),
 ):
     """Generate LLM completions for a given input file.
 
@@ -74,10 +74,7 @@ def script(
     extra_arguments = f'{" ".join(ctx.args)}'
 
     cluster_config = get_cluster_config(cluster, config_dir)
-    if log_dir:
-        check_if_mounted(cluster_config, log_dir)
-    else:
-        log_dir = str(Path('.').absolute() / 'script-logs')
+    check_if_mounted(cluster_config, log_dir)
 
     with run.Experiment(expname) as exp:
         _ = add_task(

--- a/nemo_skills/pipeline/script.py
+++ b/nemo_skills/pipeline/script.py
@@ -36,11 +36,7 @@ def get_cmd(module, script, extra_arguments):
         cmd = f"python -m {module} "
 
     cmd += f" {extra_arguments} "
-    cmd = (
-        f"export PYTHONPATH=$PYTHONPATH:/nemo_run/code && "
-        f"cd /nemo_run/code && "
-        f"{cmd}"
-    )
+    cmd = f"export PYTHONPATH=$PYTHONPATH:/nemo_run/code && " f"cd /nemo_run/code && " f"{cmd}"
     return cmd
 
 
@@ -62,7 +58,7 @@ def script(
         help=(
             "Searches sys.path in the NeMo-Skills Container for the named module and runs the "
             "corresponding .py file as a script."
-        )
+        ),
     ),
     script: str = typer.Option(
         None,
@@ -79,9 +75,7 @@ def script(
     config_dir: str = typer.Option(None, help="Can customize where we search for cluster configs"),
     log_dir: str = typer.Option(help="Specify a custom location for slurm logs. "),
 ):
-    """Run a pre-defined module or script in the NeMo-Skills container.
-
-    """
+    """Run a pre-defined module or script in the NeMo-Skills container."""
     setup_logging(disable_hydra_logs=False)
     extra_arguments = f'{" ".join(ctx.args)}'
 

--- a/nemo_skills/pipeline/script.py
+++ b/nemo_skills/pipeline/script.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from pathlib import Path
+
+import nemo_run as run
+import typer
+
+from nemo_skills.pipeline import add_task, check_if_mounted, get_cluster_config, get_generation_command, run_exp
+from nemo_skills.pipeline.app import app, typer_unpacker
+from nemo_skills.utils import setup_logging
+
+LOG = logging.getLogger(__file__)
+
+
+def get_cmd(module, extra_arguments):
+    cmd = "pip install transformers && "
+    cmd += f"time python -m {module} "
+    cmd += f" {extra_arguments} "
+    cmd = (
+        f"export PYTHONPATH=$PYTHONPATH:/nemo_run/code && "
+        f"cd /nemo_run/code && "
+        # might be required if we are not hosting server ourselves
+        f"export NVIDIA_API_KEY={os.getenv('NVIDIA_API_KEY', '')} && "
+        f"export OPENAI_API_KEY={os.getenv('OPENAI_API_KEY', '')} && "
+        f"{cmd}"
+    )
+    return cmd
+
+
+@app.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
+@typer_unpacker
+def script(
+    ctx: typer.Context,
+    cluster: str = typer.Option(
+        None,
+        help="One of the configs inside config_dir or NEMO_SKILLS_CONFIG_DIR or ./cluster_configs. "
+        "Can also use NEMO_SKILLS_CONFIG instead of specifying as argument.",
+    ),
+    expname: str = typer.Option("script", help="Nemo run experiment name"),
+    partition: str = typer.Option(
+        None, help="Can specify if need interactive jobs or a specific non-default partition"
+    ),
+    module: str = typer.Option(help=(
+        "Searches sys.path in the NeMo-Skills Container for the named module and runs the "
+        "corresponding .py file as a script."
+    )),
+    num_gpus: int = typer.Option(1, help="Number of GPUs to use"),
+    run_after: str = typer.Option(
+        None, help="Can specify an expname that needs to be completed before this one starts"
+    ),
+    config_dir: str = typer.Option(None, help="Can customize where we search for cluster configs"),
+    log_dir: str = typer.Option(None, help="Can specify a custom location for slurm logs. "),
+):
+    """Generate LLM completions for a given input file.
+
+    Run `python -m nemo_skills.inference.generate --help` for other supported arguments
+    (need to be prefixed with ++, since we use Hydra for that script).
+    """
+    setup_logging(disable_hydra_logs=False)
+    extra_arguments = f'{" ".join(ctx.args)}'
+
+    cluster_config = get_cluster_config(cluster, config_dir)
+    if log_dir:
+        check_if_mounted(cluster_config, log_dir)
+    else:
+        log_dir = str(Path('.').absolute() / 'script-logs')
+
+    with run.Experiment(expname) as exp:
+        _ = add_task(
+            exp,
+            cmd=get_cmd(module=module, extra_arguments=extra_arguments),
+            task_name="script",
+            log_dir=log_dir,
+            container=cluster_config["containers"]["nemo-skills"],
+            cluster_config=cluster_config,
+            partition=partition,
+            run_after=run_after,
+            num_gpus=num_gpus,
+        )
+        run_exp(exp, cluster_config)
+
+
+if __name__ == "__main__":
+    typer.main.get_command_name = lambda name: name
+    app()
+

--- a/nemo_skills/pipeline/script.py
+++ b/nemo_skills/pipeline/script.py
@@ -36,7 +36,7 @@ def get_cmd(module, script, extra_arguments):
         cmd = f"python -m {module} "
 
     cmd += f" {extra_arguments} "
-    cmd = f"export PYTHONPATH=$PYTHONPATH:/nemo_run/code && " f"cd /nemo_run/code && " f"{cmd}"
+    cmd = f"export PYTHONPATH=$PYTHONPATH:/nemo_run/code && cd /nemo_run/code && {cmd}"
     return cmd
 
 
@@ -63,7 +63,7 @@ def script(
     script: str = typer.Option(
         None,
         help=(
-            "Path to the python script to run. The script must in the git index "
+            "Path to the python script to run. The script must be in the git index "
             "of the directory where this command is run. The relative path to the script "
             "from the current working directory should be provided."
         ),

--- a/nemo_skills/pipeline/script.py
+++ b/nemo_skills/pipeline/script.py
@@ -53,10 +53,12 @@ def script(
     partition: str = typer.Option(
         None, help="Can specify if need interactive jobs or a specific non-default partition"
     ),
-    module: str = typer.Option(help=(
-        "Searches sys.path in the NeMo-Skills Container for the named module and runs the "
-        "corresponding .py file as a script."
-    )),
+    module: str = typer.Option(
+        help=(
+            "Searches sys.path in the NeMo-Skills Container for the named module and runs the "
+            "corresponding .py file as a script."
+        )
+    ),
     num_gpus: int = typer.Option(1, help="Number of GPUs to use"),
     run_after: str = typer.Option(
         None, help="Can specify an expname that needs to be completed before this one starts"
@@ -93,4 +95,3 @@ def script(
 if __name__ == "__main__":
     typer.main.get_command_name = lambda name: name
     app()
-

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -95,8 +95,6 @@ def get_generation_command(server_address, generation_commands):
         f"export PYTHONPATH=$PYTHONPATH:/nemo_run/code && "
         f"cd /nemo_run/code && "
         # might be required if we are not hosting server ourselves
-        f"export NVIDIA_API_KEY={os.getenv('NVIDIA_API_KEY', '')} && "
-        f"export OPENAI_API_KEY={os.getenv('OPENAI_API_KEY', '')} && "
         # this will try to handshake in a loop and unblock when the server responds
         f"echo 'Waiting for the server to start at {server_address}' && "
         f"while [ $(curl -X PUT {server_address} >/dev/null 2>&1; echo $?) -ne 0 ]; do sleep 3; done && "
@@ -155,7 +153,6 @@ def get_reward_server_command(
         f"nvidia-smi && "
         f"cd /nemo_run/code && "
         f"export PYTHONPATH=$PYTHONPATH:/nemo_run/code && "
-        f"export HF_TOKEN={get_token()} && "
         f"{server_start_cmd} "
     )
     return server_cmd, num_tasks
@@ -468,7 +465,7 @@ def get_env_variables(cluster_config):
     - `required_env_vars` - list of required environment variables
     - `env_vars` - list of optional environment variables
 
-    NVIDIA_API_KEY and OPENAI_API_KEY are always added if they exist.
+    NVIDIA_API_KEY, OPENAI_API_KEY, and HF_TOKEN are always added if they exist.
 
     Args:
         cluster_config: cluster config dictionary
@@ -489,13 +486,19 @@ def get_env_variables(cluster_config):
     # It is fine to have these as always optional even if they are required for some configs
     # Assume it is required, then this will override the value set above with the same
     # value, assuming it has not been updated externally between these two calls
-    always_optional_env_vars = ["NVIDIA_API_KEY", "OPENAI_API_KEY"]
+    always_optional_env_vars = ["NVIDIA_API_KEY", "OPENAI_API_KEY", "HF_TOKEN"]
+    default_factories = {
+        "HF_TOKEN": get_token,
+    }
     # Add optional env variables
     optional_env_vars = cluster_config.get("env_vars", [])
     for env_var in optional_env_vars + always_optional_env_vars:
         if env_var in os.environ:
             logging.info(f"Adding optional environment variable {env_var} (value={os.environ[env_var]})")
             env_vars[env_var] = os.environ[env_var]
+        elif env_var in default_factories:
+            env_vars[env_var] = default_factories[env_var]()
+            logging.info(f"Adding optional environment variable {env_var} (value={env_vars[env_var]})")
         else:
             logging.info(f"Optional environment variable {env_var} not found in user environment; skipping.")
 

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -493,11 +493,11 @@ def get_env_variables(cluster_config):
     optional_env_vars = cluster_config.get("env_vars", [])
     for env_var in optional_env_vars + always_optional_env_vars:
         if env_var in os.environ:
-            logging.info(f"Adding optional environment variable {env_var} (value={os.environ[env_var]})")
+            logging.info(f"Adding optional environment variable {env_var} from environment")
             env_vars[env_var] = os.environ[env_var]
         elif env_var in default_factories:
             env_vars[env_var] = default_factories[env_var]()
-            logging.info(f"Adding optional environment variable {env_var} (value={env_vars[env_var]})")
+            logging.info(f"Adding optional environment variable {env_var} from environment")
         else:
             logging.info(f"Optional environment variable {env_var} not found in user environment; skipping.")
 

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -468,6 +468,8 @@ def get_env_variables(cluster_config):
     - `required_env_vars` - list of required environment variables
     - `env_vars` - list of optional environment variables
 
+    NVIDIA_API_KEY and OPENAI_API_KEY are always added if they exist.
+
     Args:
         cluster_config: cluster config dictionary
 
@@ -484,9 +486,13 @@ def get_env_variables(cluster_config):
         env_vars[env_var] = os.environ[env_var]
         logging.info(f"Adding required environment variable {env_var} (value={os.environ[env_var]})")
 
+    # It is fine to have these as always optional even if they are required for some configs
+    # Assume it is required, then this will override the value set above with the same
+    # value, assuming it has not been updated externally between these two calls
+    always_optional_env_vars = ["NVIDIA_API_KEY", "OPENAI_API_KEY"]
     # Add optional env variables
     optional_env_vars = cluster_config.get("env_vars", [])
-    for env_var in optional_env_vars:
+    for env_var in optional_env_vars + always_optional_env_vars:
         if env_var in os.environ:
             logging.info(f"Adding optional environment variable {env_var} (value={os.environ[env_var]})")
             env_vars[env_var] = os.environ[env_var]

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -216,7 +216,6 @@ def get_server_command(
         f"nvidia-smi && "
         f"cd /nemo_run/code && "
         f"export PYTHONPATH=$PYTHONPATH:/nemo_run/code && "
-        f"export HF_TOKEN={get_token()} && "
         f"{server_start_cmd} "
     )
     return server_cmd, num_tasks

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -669,6 +669,10 @@ def add_task(
         dependencies = tuple(get_exp_handles(run_after))
     else:
         dependencies = None
+
+    if num_gpus is None and cluster_config['executor'] == "slurm":
+        num_gpus = 1
+
     commands = []
     executors = []
     # assuming server always has the largest resources request, so it needs to go first

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -27,4 +27,5 @@ scikit-learn
 sdp @ git+https://github.com/NVIDIA/NeMo-speech-data-processor
 sympy
 tqdm
+transformers
 typer

--- a/tests/test_data_preparation.py
+++ b/tests/test_data_preparation.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import hashlib
+import sys
 import uuid
 from pathlib import Path
-import sys
+
 import yaml
 
 from nemo_skills.pipeline import wrap_arguments
@@ -32,6 +33,7 @@ def compute_md5(file_path):
             hash_md5.update(chunk)
     return hash_md5.hexdigest()
 
+
 def docker_mkdir(directory):
     test_config_path = Path(__file__).absolute().parent / "gpu-tests" / "test-local.yaml"
     config = yaml.safe_load(open(test_config_path).read())
@@ -43,6 +45,7 @@ def docker_mkdir(directory):
         volume_paths=volumes,
         command=cmd,
     )
+
 
 def test_multiple_files():
     output_file = f"/mnt/datadrive/nemo-skills-test-data/tests/data/processed_multifile_output_{uuid.uuid4()}.jsonl"

--- a/tests/test_data_preparation.py
+++ b/tests/test_data_preparation.py
@@ -55,13 +55,13 @@ def docker_rm_and_mkdir(file_):
 
 
 def test_multiple_files():
-    output_file = f"/tmp/tests/data/processed_multifile_output.jsonl"
+    output_file = f"/tmp/nemo-skills-tests/data/processed_multifile_output.jsonl"
     docker_rm_and_mkdir(output_file)
     run_cmd(
         module="nemo_skills.training.prepare_sft_data ",
         cluster='test-local',
         config_dir=Path(__file__).parent / 'gpu-tests',
-        log_dir='/tmp/test_multiple_files',
+        log_dir='/tmp/nemo-skills-tests/test_multiple_files',
         num_gpus=0,
         ctx=wrap_arguments(
             f"    ++input_files='tests/data/output-rs*.test' "
@@ -89,13 +89,13 @@ def test_multiple_files():
 
 
 def test_exclude_keys():
-    output_file = f"/tmp/tests/data/processed_compact_output.jsonl"
+    output_file = f"/tmp/nemo-skills-tests/data/processed_compact_output.jsonl"
     docker_rm_and_mkdir(output_file)
     run_cmd(
         module="nemo_skills.training.prepare_sft_data ",
         cluster='test-local',
         config_dir=Path(__file__).parent / 'gpu-tests',
-        log_dir='/tmp/test_exclude_keys',
+        log_dir='/tmp/nemo-skills-tests/test_exclude_keys',
         num_gpus=0,
         ctx=wrap_arguments(
             f"    ++input_files='tests/data/output-rs*.test' "
@@ -123,13 +123,13 @@ def test_exclude_keys():
 
 
 def test_code_sft_data():
-    output_file = f"/tmp/tests/data/code_processed_output.jsonl"
+    output_file = f"/tmp/nemo-skills-tests/data/code_processed_output.jsonl"
     docker_rm_and_mkdir(output_file)
     run_cmd(
         module="nemo_skills.training.prepare_sft_data ",
         cluster='test-local',
         config_dir=Path(__file__).parent / 'gpu-tests',
-        log_dir='/tmp/test_code_sft_data',
+        log_dir='/tmp/nemo-skills-tests/test_code_sft_data',
         num_gpus=0,
         ctx=wrap_arguments(
             f"    --config-name=prepare_code_sft_data "
@@ -152,13 +152,13 @@ def test_code_sft_data():
 
 
 def test_openmathinstruct2():
-    output_file = f"/tmp/tests/data/openmathinstruct2-sft.jsonl"
+    output_file = f"/tmp/nemo-skills-tests/data/openmathinstruct2-sft.jsonl"
     docker_rm_and_mkdir(output_file)
     run_cmd(
         module="nemo_skills.training.prepare_sft_data ",
         cluster='test-local',
         config_dir=Path(__file__).parent / 'gpu-tests',
-        log_dir='/tmp/test_openmathinstruct2',
+        log_dir='/tmp/nemo-skills-tests/test_openmathinstruct2',
         num_gpus=0,
         ctx=wrap_arguments(
             "++preprocessed_dataset_files='tests/data/openmathinstruct2.test' "

--- a/tests/test_data_preparation.py
+++ b/tests/test_data_preparation.py
@@ -13,7 +13,11 @@
 # limitations under the License.
 
 import hashlib
-import subprocess
+from pathlib import Path
+import uuid
+
+from nemo_skills.pipeline import wrap_arguments
+from nemo_skills.pipeline.cli import run_cmd
 
 
 def compute_md5(file_path):
@@ -25,24 +29,29 @@ def compute_md5(file_path):
 
 
 def test_multiple_files():
-    output_file = "tests/data/processed_multifile_output.jsonl"
-    subprocess.run(
-        "python -m nemo_skills.training.prepare_sft_data "
-        f"    ++input_files='tests/data/output-rs*.test' "
-        f"    ++output_path={output_file} "
-        f"    ++prompt_config=generic/math "
-        f"    ++prompt_template=llama3-instruct "
-        f"    ++exclude_optional_keys=false "
-        f"    ++filters.remove_len_outlier_problems=false "
-        f"    ++filters.drop_multi_boxed=true "
-        f"    ++filters.trim_solutions=true "
-        f"    ++filters.drop_incorrect_arithmetic=false "
-        f"    ++filters.split_arithmetic=false "
-        f"    ++num_output_samples=32 "
-        f"    ++downsampling_method=fair "
-        f"    ++do_shuffle=false ",
-        check=True,
-        shell=True,
+    output_file = f"/mnt/datadrive/nemo-skills-test-data/tests/data/processed_multifile_output_{uuid.uuid4()}.jsonl"
+    Path(output_file).absolute().parent.mkdir(parents=True, exist_ok=True)
+    run_cmd(
+        module="nemo_skills.training.prepare_sft_data ",
+        cluster='test-local',
+        config_dir=Path(__file__).parent / 'gpu-tests',
+        log_dir='/tmp/test_multiple_files',
+        num_gpus=0,
+        ctx=wrap_arguments(
+            f"    ++input_files='tests/data/output-rs*.test' "
+            f"    ++output_path={output_file} "
+            f"    ++prompt_config=generic/math "
+            f"    ++prompt_template=llama3-instruct "
+            f"    ++exclude_optional_keys=false "
+            f"    ++filters.remove_len_outlier_problems=false "
+            f"    ++filters.drop_multi_boxed=true "
+            f"    ++filters.trim_solutions=true "
+            f"    ++filters.drop_incorrect_arithmetic=false "
+            f"    ++filters.split_arithmetic=false "
+            f"    ++num_output_samples=32 "
+            f"    ++downsampling_method=fair "
+            f"    ++do_shuffle=false "
+        ),
     )
 
     expected_md5 = "3971b33e2dd9ed28b2edc323eac19a1f"
@@ -54,24 +63,29 @@ def test_multiple_files():
 
 
 def test_exclude_keys():
-    output_file = "tests/data/processed_compact_output.jsonl"
-    subprocess.run(
-        "python -m nemo_skills.training.prepare_sft_data "
-        f"    ++input_files='tests/data/output-rs*.test' "
-        f"    ++output_path={output_file} "
-        f"    ++prompt_config=generic/math "
-        f"    ++prompt_template=llama3-instruct "
-        f"    ++exclude_optional_keys=true "
-        f"    ++filters.remove_len_outlier_problems=false "
-        f"    ++filters.drop_multi_boxed=true "
-        f"    ++filters.trim_solutions=true "
-        f"    ++filters.drop_incorrect_arithmetic=false "
-        f"    ++filters.split_arithmetic=false "
-        f"    ++num_output_samples=32 "
-        f"    ++downsampling_method=fair "
-        f"    ++do_shuffle=false ",
-        check=True,
-        shell=True,
+    output_file = f"/mnt/datadrive/nemo-skills-test-data/tests/data/processed_compact_output_{uuid.uuid4()}.jsonl"
+    Path(output_file).absolute().parent.mkdir(parents=True, exist_ok=True)
+    run_cmd(
+        module="nemo_skills.training.prepare_sft_data ",
+        cluster='test-local',
+        config_dir=Path(__file__).parent / 'gpu-tests',
+        log_dir='/tmp/test_exclude_keys',
+        num_gpus=0,
+        ctx=wrap_arguments(
+            f"    ++input_files='tests/data/output-rs*.test' "
+            f"    ++output_path={output_file} "
+            f"    ++prompt_config=generic/math "
+            f"    ++prompt_template=llama3-instruct "
+            f"    ++exclude_optional_keys=true "
+            f"    ++filters.remove_len_outlier_problems=false "
+            f"    ++filters.drop_multi_boxed=true "
+            f"    ++filters.trim_solutions=true "
+            f"    ++filters.drop_incorrect_arithmetic=false "
+            f"    ++filters.split_arithmetic=false "
+            f"    ++num_output_samples=32 "
+            f"    ++downsampling_method=fair "
+            f"    ++do_shuffle=false ",
+        )
     )
 
     expected_md5 = "7144c098a6e75ffd01c29e714552db24"
@@ -83,19 +97,24 @@ def test_exclude_keys():
 
 
 def test_code_sft_data():
-    output_file = "tests/data/code_processed_output.jsonl"
-    subprocess.run(
-        "python -m nemo_skills.training.prepare_sft_data "
-        f"    --config-name=prepare_code_sft_data "
-        f"    ++preprocessed_dataset_files='tests/data/code-output.test' "
-        f"    ++output_path={output_file} "
-        f"    ++prompt_config=generic/codegen "
-        f"    ++prompt_template=llama3-instruct "
-        f"    ++exclude_optional_keys=false "
-        f"    ++filters.drop_incorrect_code_blocks=false "
-        f"    ++generation_suffix='\"<|eot_id|>\"' ",
-        check=True,
-        shell=True,
+    output_file = f"/mnt/datadrive/nemo-skills-test-data/tests/data/code_processed_output_{uuid.uuid4()}.jsonl"
+    Path(output_file).absolute().parent.mkdir(parents=True, exist_ok=True)
+    run_cmd(
+        module="nemo_skills.training.prepare_sft_data ",
+        cluster='test-local',
+        config_dir=Path(__file__).parent / 'gpu-tests',
+        log_dir='/tmp/test_code_sft_data',
+        num_gpus=0,
+        ctx=wrap_arguments(
+            f"    --config-name=prepare_code_sft_data "
+            f"    ++preprocessed_dataset_files='tests/data/code-output.test' "
+            f"    ++output_path={output_file} "
+            f"    ++prompt_config=generic/codegen "
+            f"    ++prompt_template=llama3-instruct "
+            f"    ++exclude_optional_keys=false "
+            f"    ++filters.drop_incorrect_code_blocks=false "
+            f"    ++generation_suffix='\"<|eot_id|>\"' ",
+        )
     )
 
     expected_md5 = "a830a174291795cc7db0d1c3ee39de25"
@@ -107,25 +126,29 @@ def test_code_sft_data():
 
 
 def test_openmathinstruct2():
-    output_file = "tests/data/openmathinstruct2-sft.jsonl"
+    output_file = f"/mnt/datadrive/nemo-skills-test-data/tests/data/openmathinstruct2-sft_{uuid.uuid4()}.jsonl"
+    Path(output_file).absolute().parent.mkdir(parents=True, exist_ok=True)
 
-    subprocess.run(
-        "python -m nemo_skills.training.prepare_sft_data "
-        "++preprocessed_dataset_files='tests/data/openmathinstruct2.test' "
-        f"output_path={output_file} "
-        "++prompt_template=llama3-instruct "
-        "++prompt_config=generic/math "
-        "++output_key=generated_solution "
-        "++output_path='tests/data/openmathinstruct2-sft.jsonl' "
-        "++filters.remove_len_outlier_problems=false "
-        "++filters.drop_multi_boxed=false "
-        "++filters.trim_prefix=false "
-        "++filters.trim_solutions=false "
-        "++filters.drop_incorrect_arithmetic=false "
-        "++filters.split_arithmetic=false "
-        "++generation_suffix='\"<|eot_id|>\"'",
-        check=True,
-        shell=True,
+    run_cmd(
+        module="nemo_skills.training.prepare_sft_data ",
+        cluster='test-local',
+        config_dir=Path(__file__).parent / 'gpu-tests',
+        log_dir='/tmp/test_openmathinstruct2',
+        num_gpus=0,
+        ctx=wrap_arguments(
+            "++preprocessed_dataset_files='tests/data/openmathinstruct2.test' "
+            f"++output_path={output_file} "
+            "++prompt_template=llama3-instruct "
+            "++prompt_config=generic/math "
+            "++output_key=generated_solution "
+            "++filters.remove_len_outlier_problems=false "
+            "++filters.drop_multi_boxed=false "
+            "++filters.trim_prefix=false "
+            "++filters.trim_solutions=false "
+            "++filters.drop_incorrect_arithmetic=false "
+            "++filters.split_arithmetic=false "
+            "++generation_suffix='\"<|eot_id|>\"'",
+        )
     )
 
     expected_md5 = "981e11051436be68cdc45953888a5685"

--- a/tests/test_data_preparation.py
+++ b/tests/test_data_preparation.py
@@ -40,17 +40,11 @@ def docker_rm_and_mkdir(file_):
     config = yaml.safe_load(open(test_config_path).read())
     volumes = config['mounts']
     container = config['containers']['nemo-skills']
-    rm_cmd = f"rm -f {str(file_)}"
-    mkdir_cmd = f"mkdir -p {str(directory)}"
+    rm_mkdir_cmd = f"rm -f {str(file_)} && mkdir -p {str(directory)}"
     docker_run(
         image_name=container,
         volume_paths=volumes,
-        command=rm_cmd,
-    )
-    docker_run(
-        image_name=container,
-        volume_paths=volumes,
-        command=mkdir_cmd,
+        command=rm_mkdir_cmd,
     )
 
 
@@ -62,7 +56,6 @@ def test_multiple_files():
         cluster='test-local',
         config_dir=Path(__file__).parent / 'gpu-tests',
         log_dir='/tmp/nemo-skills-tests/test_multiple_files',
-        num_gpus=0,
         ctx=wrap_arguments(
             f"    ++input_files='tests/data/output-rs*.test' "
             f"    ++output_path={output_file} "
@@ -96,7 +89,6 @@ def test_exclude_keys():
         cluster='test-local',
         config_dir=Path(__file__).parent / 'gpu-tests',
         log_dir='/tmp/nemo-skills-tests/test_exclude_keys',
-        num_gpus=0,
         ctx=wrap_arguments(
             f"    ++input_files='tests/data/output-rs*.test' "
             f"    ++output_path={output_file} "
@@ -130,7 +122,6 @@ def test_code_sft_data():
         cluster='test-local',
         config_dir=Path(__file__).parent / 'gpu-tests',
         log_dir='/tmp/nemo-skills-tests/test_code_sft_data',
-        num_gpus=0,
         ctx=wrap_arguments(
             f"    --config-name=prepare_code_sft_data "
             f"    ++preprocessed_dataset_files='tests/data/code-output.test' "
@@ -159,7 +150,6 @@ def test_openmathinstruct2():
         cluster='test-local',
         config_dir=Path(__file__).parent / 'gpu-tests',
         log_dir='/tmp/nemo-skills-tests/test_openmathinstruct2',
-        num_gpus=0,
         ctx=wrap_arguments(
             "++preprocessed_dataset_files='tests/data/openmathinstruct2.test' "
             f"++output_path={output_file} "

--- a/tests/test_data_preparation.py
+++ b/tests/test_data_preparation.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import hashlib
-from pathlib import Path
 import uuid
+from pathlib import Path
 
 from nemo_skills.pipeline import wrap_arguments
 from nemo_skills.pipeline.cli import run_cmd
@@ -85,7 +85,7 @@ def test_exclude_keys():
             f"    ++num_output_samples=32 "
             f"    ++downsampling_method=fair "
             f"    ++do_shuffle=false ",
-        )
+        ),
     )
 
     expected_md5 = "7144c098a6e75ffd01c29e714552db24"
@@ -114,7 +114,7 @@ def test_code_sft_data():
             f"    ++exclude_optional_keys=false "
             f"    ++filters.drop_incorrect_code_blocks=false "
             f"    ++generation_suffix='\"<|eot_id|>\"' ",
-        )
+        ),
     )
 
     expected_md5 = "a830a174291795cc7db0d1c3ee39de25"
@@ -148,7 +148,7 @@ def test_openmathinstruct2():
             "++filters.drop_incorrect_arithmetic=false "
             "++filters.split_arithmetic=false "
             "++generation_suffix='\"<|eot_id|>\"'",
-        )
+        ),
     )
 
     expected_md5 = "981e11051436be68cdc45953888a5685"

--- a/tests/test_data_preparation.py
+++ b/tests/test_data_preparation.py
@@ -34,22 +34,29 @@ def compute_md5(file_path):
     return hash_md5.hexdigest()
 
 
-def docker_mkdir(directory):
+def docker_rm_and_mkdir(file_):
+    directory = Path(file_).absolute().parent
     test_config_path = Path(__file__).absolute().parent / "gpu-tests" / "test-local.yaml"
     config = yaml.safe_load(open(test_config_path).read())
     volumes = config['mounts']
     container = config['containers']['nemo-skills']
-    cmd = f"mkdir -p {str(directory)}"
+    rm_cmd = f"rm -f {str(file_)}"
+    mkdir_cmd = f"mkdir -p {str(directory)}"
     docker_run(
         image_name=container,
         volume_paths=volumes,
-        command=cmd,
+        command=rm_cmd,
+    )
+    docker_run(
+        image_name=container,
+        volume_paths=volumes,
+        command=mkdir_cmd,
     )
 
 
 def test_multiple_files():
-    output_file = f"/mnt/datadrive/nemo-skills-test-data/tests/data/processed_multifile_output_{uuid.uuid4()}.jsonl"
-    docker_mkdir(Path(output_file).absolute().parent)
+    output_file = f"/tmp/tests/data/processed_multifile_output.jsonl"
+    docker_rm_and_mkdir(output_file)
     run_cmd(
         module="nemo_skills.training.prepare_sft_data ",
         cluster='test-local',
@@ -82,8 +89,8 @@ def test_multiple_files():
 
 
 def test_exclude_keys():
-    output_file = f"/mnt/datadrive/nemo-skills-test-data/tests/data/processed_compact_output_{uuid.uuid4()}.jsonl"
-    docker_mkdir(Path(output_file).absolute().parent)
+    output_file = f"/tmp/tests/data/processed_compact_output.jsonl"
+    docker_rm_and_mkdir(output_file)
     run_cmd(
         module="nemo_skills.training.prepare_sft_data ",
         cluster='test-local',
@@ -116,8 +123,8 @@ def test_exclude_keys():
 
 
 def test_code_sft_data():
-    output_file = f"/mnt/datadrive/nemo-skills-test-data/tests/data/code_processed_output_{uuid.uuid4()}.jsonl"
-    docker_mkdir(Path(output_file).absolute().parent)
+    output_file = f"/tmp/tests/data/code_processed_output.jsonl"
+    docker_rm_and_mkdir(output_file)
     run_cmd(
         module="nemo_skills.training.prepare_sft_data ",
         cluster='test-local',
@@ -145,8 +152,8 @@ def test_code_sft_data():
 
 
 def test_openmathinstruct2():
-    output_file = f"/mnt/datadrive/nemo-skills-test-data/tests/data/openmathinstruct2-sft_{uuid.uuid4()}.jsonl"
-    docker_mkdir(Path(output_file).absolute().parent)
+    output_file = f"/tmp/tests/data/openmathinstruct2-sft.jsonl"
+    docker_rm_and_mkdir(output_file)
     run_cmd(
         module="nemo_skills.training.prepare_sft_data ",
         cluster='test-local',


### PR DESCRIPTION
Enables calling arbtirary modules as scripts  through NeMo-Skills, e.g.,

```bash
ns run_cmd --module nemo_skills.training.prepare_sft_data \
    --cluster=local \
    ++input_files=...
```