### PR TITLE
Enable external libraries to be run outside of their root dir

### DIFF
--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -429,20 +429,17 @@ def get_packager(cluster_config, env_vars):
     include_patterns = []
     include_pattern_relative_paths = []
 
-    if repo_path is not None:
-        include_patterns.append(str(Path(repo_path) / '*'))
-        include_pattern_relative_paths.append(repo_path)
-
     try:
-        repo_path = (
-            subprocess.run(
-                ["git", "rev-parse", "--show-toplevel"],
-                capture_output=True,
-                check=True,
+        if not repo_path:
+            repo_path = (
+                subprocess.run(
+                    ["git", "rev-parse", "--show-toplevel"],
+                    capture_output=True,
+                    check=True,
+                )
+                .stdout.decode()
+                .strip()
             )
-            .stdout.decode()
-            .strip()
-        )
 
         # Do we have nemo_skills package in this repo? If no, we need to pick it up from installed location
         if not (Path(repo_path) / 'nemo_skills').is_dir():
@@ -462,6 +459,7 @@ def get_packager(cluster_config, env_vars):
 
         check_uncommited_changes = not bool(os.getenv('NEMO_SKILLS_DISABLE_UNCOMMITTED_CHANGES_CHECK', 0))
         return run.GitArchivePackager(
+            basepath=repo_path,
             include_pattern=include_patterns,
             include_pattern_relative_path=include_pattern_relative_paths,
             check_uncommitted_changes=check_uncommited_changes,

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -459,6 +459,7 @@ def get_packager(cluster_config, env_vars):
 
         check_uncommited_changes = not bool(os.getenv('NEMO_SKILLS_DISABLE_UNCOMMITTED_CHANGES_CHECK', 0))
         return run.GitArchivePackager(
+            basepath=repo_path,
             include_pattern=include_patterns,
             include_pattern_relative_path=include_pattern_relative_paths,
             check_uncommitted_changes=check_uncommited_changes,
@@ -468,6 +469,10 @@ def get_packager(cluster_config, env_vars):
             "Not running from a git repo, trying to upload installed package. Make sure there are no extra files in %s",
             str(Path(__file__).absolute().parents[1] / '*'),
         )
+
+        if repo_path is not None:
+            include_patterns.append(str(Path(repo_path) / '*'))
+            include_pattern_relative_paths.append(repo_path)
 
         include_patterns.append(str(Path(__file__).absolute().parents[1] / '*'))
         include_pattern_relative_paths.append(str(Path(__file__).absolute().parents[2]))

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -432,12 +432,18 @@ def get_packager():
 
         # Do we have nemo_skills package in this repo? If no, we need to pick it up from installed location
         if not (Path(repo_path) / 'nemo_skills').is_dir():
+
+            if 'NEMO_SKILLS_GIT_PACKAGE_ROOT_DIR' in os.environ:
+                # if we are in an external git repo but a library wants to upload the installed package
+                include_pattern = str(Path(os.environ['NEMO_SKILLS_GIT_PACKAGE_ROOT_DIR']) / '*')
+            else:
+                include_pattern = str(Path(__file__).absolute().parents[1] / '*')
+
             logging.warning(
                 "Not running from NeMo-Skills repo, trying to upload installed package. "
                 "Make sure there are no extra files in %s",
-                str(Path(__file__).absolute().parents[1] / '*'),
+                include_pattern,
             )
-            include_pattern = str(Path(__file__).absolute().parents[1] / '*')
         else:
             # picking up local dataset files if we are in the right repo
             include_pattern = str(Path(__file__).absolute().parents[1] / "dataset/**/*.jsonl")

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -457,6 +457,10 @@ def get_packager(cluster_config, env_vars):
         include_patterns.append(skills_include_pattern)
         include_pattern_relative_paths.append(skills_include_pattern_relative_path)
 
+        # try multiple patterns
+        include_patterns.append("/home/smajumdar/PycharmProjects/gradio-json-markdown/*")
+        include_pattern_relative_paths.append("/home/smajumdar/PycharmProjects/gradio-json-markdown")
+
         check_uncommited_changes = not bool(os.getenv('NEMO_SKILLS_DISABLE_UNCOMMITTED_CHANGES_CHECK', 0))
         return run.GitArchivePackager(
             basepath=repo_path,

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -457,10 +457,6 @@ def get_packager(cluster_config, env_vars):
         include_patterns.append(skills_include_pattern)
         include_pattern_relative_paths.append(skills_include_pattern_relative_path)
 
-        # try multiple patterns
-        include_patterns.append("/home/smajumdar/PycharmProjects/gradio-json-markdown/*")
-        include_pattern_relative_paths.append("/home/smajumdar/PycharmProjects/gradio-json-markdown")
-
         check_uncommited_changes = not bool(os.getenv('NEMO_SKILLS_DISABLE_UNCOMMITTED_CHANGES_CHECK', 0))
         return run.GitArchivePackager(
             basepath=repo_path,

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -425,6 +425,7 @@ def get_packager(cluster_config, env_vars):
     elif 'NEMO_SKILLS_GIT_PACKAGE_ROOT_DIR' in env_vars:
         repo_path = str(Path(env_vars['NEMO_SKILLS_GIT_PACKAGE_ROOT_DIR']))
 
+    # TODO: Add support to read cluster_config for additional include patterns
     include_patterns = []
     include_pattern_relative_paths = []
 

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -428,18 +428,20 @@ def get_packager(cluster_config, env_vars):
     include_patterns = []
     include_pattern_relative_paths = []
 
+    if repo_path is not None:
+        include_patterns.append(str(Path(repo_path) / '*'))
+        include_pattern_relative_paths.append(repo_path)
+
     try:
-        if repo_path is None:
-            # are we in a git repo? If yes, we are uploading the current code
-            repo_path = (
-                subprocess.run(
-                    ["git", "rev-parse", "--show-toplevel"],
-                    capture_output=True,
-                    check=True,
-                )
-                .stdout.decode()
-                .strip()
+        repo_path = (
+            subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                capture_output=True,
+                check=True,
             )
+            .stdout.decode()
+            .strip()
+        )
 
         # Do we have nemo_skills package in this repo? If no, we need to pick it up from installed location
         if not (Path(repo_path) / 'nemo_skills').is_dir():
@@ -459,7 +461,6 @@ def get_packager(cluster_config, env_vars):
 
         check_uncommited_changes = not bool(os.getenv('NEMO_SKILLS_DISABLE_UNCOMMITTED_CHANGES_CHECK', 0))
         return run.GitArchivePackager(
-            basepath=repo_path,
             include_pattern=include_patterns,
             include_pattern_relative_path=include_pattern_relative_paths,
             check_uncommitted_changes=check_uncommited_changes,
@@ -469,10 +470,6 @@ def get_packager(cluster_config, env_vars):
             "Not running from a git repo, trying to upload installed package. Make sure there are no extra files in %s",
             str(Path(__file__).absolute().parents[1] / '*'),
         )
-
-        if repo_path is not None:
-            include_patterns.append(str(Path(repo_path) / '*'))
-            include_pattern_relative_paths.append(repo_path)
 
         include_patterns.append(str(Path(__file__).absolute().parents[1] / '*'))
         include_pattern_relative_paths.append(str(Path(__file__).absolute().parents[2]))

--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -420,10 +420,10 @@ def get_packager(cluster_config, env_vars):
     """Will check if we are running from a git repo and use git packager or default packager otherwise."""
     # Check for repo root if available
     repo_path = None
-    if 'NEMO_SKILLS_GIT_PACKAGE_ROOT_DIR' in os.environ:
-        repo_path = str(Path(os.environ['NEMO_SKILLS_GIT_PACKAGE_ROOT_DIR']))
-    elif 'NEMO_SKILLS_GIT_PACKAGE_ROOT_DIR' in env_vars:
-        repo_path = str(Path(env_vars['NEMO_SKILLS_GIT_PACKAGE_ROOT_DIR']))
+    if 'NEMO_SKILLS_OVERRIDE_GIT_REPO' in os.environ:
+        repo_path = str(Path(os.environ['NEMO_SKILLS_OVERRIDE_GIT_REPO']))
+    elif 'NEMO_SKILLS_OVERRIDE_GIT_REPO' in env_vars:
+        repo_path = str(Path(env_vars['NEMO_SKILLS_OVERRIDE_GIT_REPO']))
 
     # TODO: Add support to read cluster_config for additional include patterns
     include_patterns = []


### PR DESCRIPTION
# Info
Currently, `ns` command can be run from any location, however dependent libraries cannot be run from any place other than the root of their own git directory. 

This change enables downstream libraries to change the default git repo that is packaged inside nemo run archives.