### PR TITLE
ENH use current user for docker executor to avoid root permissions mangling

### DIFF
--- a/nemo_skills/pipeline/utils.py
+++ b/nemo_skills/pipeline/utils.py
@@ -586,7 +586,7 @@ def get_executor(
         if use_root:
             additional_kwargs = dict()
         else: # otherwise, use the current user
-            # Note: numeric user id has to be used here, if we use the name, it will not work
+            # Note: numeric user/group id has to be used here, if we use the name, it will not work
             # because in that case docker will try to resolve the name to the uid and it will fail
             # because the user does not exist in the container and the /etc/passwd file
             # has not been mounted (it would be mounted after resolving uid).
@@ -596,7 +596,8 @@ def get_executor(
             # container for some reason, we would have to mount the /etc/passwd file first by
             # adding it in read-only mode to the mounts list, like "/etc/passwd:/etc/passwd:ro",
             # but there would still be no user-specific variables like $USER and $HOME.
-            additional_kwargs = {"user": os.getuid()}
+            # Similar for the group id and /etc/group file.
+            additional_kwargs = {"user": f"{os.getuid()}:{os.getgid()}"}
         return DockerExecutor(
             container_image=container,
             packager=packager,


### PR DESCRIPTION
Currently, files created or modified within Docker containers are often owned by root, leading to permission issues when users try to manipulate these files outside the container. This requires additional steps to manage files during testing because we need to run a docker container to add/remove files. By allowing Docker to run with the current user's permissions, we streamline the development workflow so files are interoperable between local context and docker context.