### PR TITLE
MAINT remove extra HF_TOKEN exports

### DIFF
--- a/nemo_skills/pipeline/convert.py
+++ b/nemo_skills/pipeline/convert.py
@@ -64,10 +64,7 @@ def get_hf_to_trtllm_cmd(
 
     tmp_engine_dir = f"{output_model}-tmp"
 
-    setup_cmd = (
-        f"export PYTHONPATH=$PYTHONPATH:/nemo_run/code && "
-        f"cd /nemo_run/code && "
-    )
+    setup_cmd = f"export PYTHONPATH=$PYTHONPATH:/nemo_run/code && " f"cd /nemo_run/code && "
 
     hf_to_trtllm_cmd = (
         f"python -m nemo_skills.conversion.hf_to_trtllm_{model_type} "

--- a/nemo_skills/pipeline/convert.py
+++ b/nemo_skills/pipeline/convert.py
@@ -32,7 +32,6 @@ def get_nemo_to_hf_cmd(
 ):
     cmd = (
         f"export PYTHONPATH=$PYTHONPATH:/nemo_run/code && "
-        f"export HF_TOKEN={get_token()} && "
         f"cd /nemo_run/code && "
         f"python -m nemo_skills.conversion.nemo_to_hf_{model_type} "
         f"    --in-path {input_model} "
@@ -67,7 +66,6 @@ def get_hf_to_trtllm_cmd(
 
     setup_cmd = (
         f"export PYTHONPATH=$PYTHONPATH:/nemo_run/code && "
-        f"export HF_TOKEN={get_token()} && "
         f"cd /nemo_run/code && "
     )
 
@@ -112,7 +110,6 @@ def get_hf_to_nemo_cmd(
 
     cmd = (
         f"export PYTHONPATH=$PYTHONPATH:/nemo_run/code && "
-        f"export HF_TOKEN={get_token()} && "
         f"cd /nemo_run/code && "
         f"python -m nemo_skills.conversion.hf_to_nemo_{model_type} "
         f"    --in-path {input_model} "

--- a/nemo_skills/pipeline/convert.py
+++ b/nemo_skills/pipeline/convert.py
@@ -64,7 +64,7 @@ def get_hf_to_trtllm_cmd(
 
     tmp_engine_dir = f"{output_model}-tmp"
 
-    setup_cmd = f"export PYTHONPATH=$PYTHONPATH:/nemo_run/code && " f"cd /nemo_run/code && "
+    setup_cmd = f"export PYTHONPATH=$PYTHONPATH:/nemo_run/code && cd /nemo_run/code && "
 
     hf_to_trtllm_cmd = (
         f"python -m nemo_skills.conversion.hf_to_trtllm_{model_type} "

--- a/nemo_skills/pipeline/train.py
+++ b/nemo_skills/pipeline/train.py
@@ -61,7 +61,6 @@ class TrainingParams:
 def get_cmd(params: TrainingParams) -> str:
     cmd = (
         f"export WANDB_API_KEY={os.getenv('WANDB_API_KEY', '')} && "
-        f"export HF_TOKEN={get_token()} && "
         f"export HYDRA_FULL_ERROR=1 && "
         f"export PYTHONPATH=$PYTHONPATH:/nemo_run/code && "
         f"cd /nemo_run/code && "


### PR DESCRIPTION
HF_TOKEN was added to the default environment variables in #240 . These can be removed without consequence.