### PR TITLE
ENH remove options from run_cmd

### DIFF
--- a/nemo_skills/pipeline/run_cmd.py
+++ b/nemo_skills/pipeline/run_cmd.py
@@ -26,8 +26,8 @@ from nemo_skills.utils import setup_logging
 LOG = logging.getLogger(__file__)
 
 
-def get_cmd(cmd, extra_arguments):
-    cmd += f" {extra_arguments} "
+def get_cmd(extra_arguments):
+    cmd = f"{extra_arguments} "
     cmd = f"export PYTHONPATH=$PYTHONPATH:/nemo_run/code && cd /nemo_run/code && {cmd}"
     return cmd
 
@@ -45,7 +45,6 @@ def run_cmd(
     partition: str = typer.Option(
         None, help="Can specify if need interactive jobs or a specific non-default partition"
     ),
-    cmd: str = typer.Option(None, help="Command to run."),
     num_gpus: int | None = typer.Option(None, help="Number of GPUs to use"),
     run_after: str = typer.Option(
         None, help="Can specify an expname that needs to be completed before this one starts"
@@ -63,7 +62,7 @@ def run_cmd(
     with run.Experiment(expname) as exp:
         add_task(
             exp,
-            cmd=get_cmd(cmd=cmd, extra_arguments=extra_arguments),
+            cmd=get_cmd(extra_arguments=extra_arguments),
             task_name="script",
             log_dir=log_dir,
             container=cluster_config["containers"]["nemo-skills"],

--- a/nemo_skills/pipeline/run_cmd.py
+++ b/nemo_skills/pipeline/run_cmd.py
@@ -26,15 +26,7 @@ from nemo_skills.utils import setup_logging
 LOG = logging.getLogger(__file__)
 
 
-def get_cmd(module, script, extra_arguments):
-    if module is not None and script is not None:
-        raise ValueError("Cannot specify both --module and --script")
-
-    if module is None:
-        cmd = f"python /nemo_run/code/{script} "
-    else:
-        cmd = f"python -m {module} "
-
+def get_cmd(cmd, extra_arguments):
     cmd += f" {extra_arguments} "
     cmd = f"export PYTHONPATH=$PYTHONPATH:/nemo_run/code && cd /nemo_run/code && {cmd}"
     return cmd
@@ -53,21 +45,7 @@ def run_cmd(
     partition: str = typer.Option(
         None, help="Can specify if need interactive jobs or a specific non-default partition"
     ),
-    module: str = typer.Option(
-        None,
-        help=(
-            "Searches sys.path in the NeMo-Skills Container for the named module and runs the "
-            "corresponding .py file as a script."
-        ),
-    ),
-    script: str = typer.Option(
-        None,
-        help=(
-            "Path to the python script to run. The script must be in the git index "
-            "of the directory where this command is run. The relative path to the script "
-            "from the current working directory should be provided."
-        ),
-    ),
+    cmd: str = typer.Option(None, help="Command to run."),
     num_gpus: int | None = typer.Option(None, help="Number of GPUs to use"),
     run_after: str = typer.Option(
         None, help="Can specify an expname that needs to be completed before this one starts"
@@ -85,7 +63,7 @@ def run_cmd(
     with run.Experiment(expname) as exp:
         add_task(
             exp,
-            cmd=get_cmd(module=module, script=script, extra_arguments=extra_arguments),
+            cmd=get_cmd(cmd=cmd, extra_arguments=extra_arguments),
             task_name="script",
             log_dir=log_dir,
             container=cluster_config["containers"]["nemo-skills"],

--- a/tests/test_data_preparation.py
+++ b/tests/test_data_preparation.py
@@ -52,11 +52,11 @@ def test_multiple_files():
     output_file = f"/tmp/nemo-skills-tests/data/processed_multifile_output.jsonl"
     docker_rm_and_mkdir(output_file)
     run_cmd(
-        cmd="python -m nemo_skills.training.prepare_sft_data ",
         cluster='test-local',
         config_dir=Path(__file__).parent / 'gpu-tests',
         log_dir='/tmp/nemo-skills-tests/test_multiple_files',
         ctx=wrap_arguments(
+            "python -m nemo_skills.training.prepare_sft_data "
             f"    ++input_files='tests/data/output-rs*.test' "
             f"    ++output_path={output_file} "
             f"    ++prompt_config=generic/math "
@@ -85,11 +85,11 @@ def test_exclude_keys():
     output_file = f"/tmp/nemo-skills-tests/data/processed_compact_output.jsonl"
     docker_rm_and_mkdir(output_file)
     run_cmd(
-        cmd="python -m nemo_skills.training.prepare_sft_data ",
         cluster='test-local',
         config_dir=Path(__file__).parent / 'gpu-tests',
         log_dir='/tmp/nemo-skills-tests/test_exclude_keys',
         ctx=wrap_arguments(
+            "python -m nemo_skills.training.prepare_sft_data "
             f"    ++input_files='tests/data/output-rs*.test' "
             f"    ++output_path={output_file} "
             f"    ++prompt_config=generic/math "
@@ -118,11 +118,11 @@ def test_code_sft_data():
     output_file = f"/tmp/nemo-skills-tests/data/code_processed_output.jsonl"
     docker_rm_and_mkdir(output_file)
     run_cmd(
-        cmd="python -m nemo_skills.training.prepare_sft_data ",
         cluster='test-local',
         config_dir=Path(__file__).parent / 'gpu-tests',
         log_dir='/tmp/nemo-skills-tests/test_code_sft_data',
         ctx=wrap_arguments(
+            "python -m nemo_skills.training.prepare_sft_data "
             f"    --config-name=prepare_code_sft_data "
             f"    ++preprocessed_dataset_files='tests/data/code-output.test' "
             f"    ++output_path={output_file} "
@@ -146,11 +146,11 @@ def test_openmathinstruct2():
     output_file = f"/tmp/nemo-skills-tests/data/openmathinstruct2-sft.jsonl"
     docker_rm_and_mkdir(output_file)
     run_cmd(
-        cmd="python -m nemo_skills.training.prepare_sft_data ",
         cluster='test-local',
         config_dir=Path(__file__).parent / 'gpu-tests',
         log_dir='/tmp/nemo-skills-tests/test_openmathinstruct2',
         ctx=wrap_arguments(
+            "python -m nemo_skills.training.prepare_sft_data "
             "++preprocessed_dataset_files='tests/data/openmathinstruct2.test' "
             f"++output_path={output_file} "
             "++prompt_template=llama3-instruct "

--- a/tests/test_data_preparation.py
+++ b/tests/test_data_preparation.py
@@ -52,7 +52,7 @@ def test_multiple_files():
     output_file = f"/tmp/nemo-skills-tests/data/processed_multifile_output.jsonl"
     docker_rm_and_mkdir(output_file)
     run_cmd(
-        module="nemo_skills.training.prepare_sft_data ",
+        cmd="python -m nemo_skills.training.prepare_sft_data ",
         cluster='test-local',
         config_dir=Path(__file__).parent / 'gpu-tests',
         log_dir='/tmp/nemo-skills-tests/test_multiple_files',
@@ -85,7 +85,7 @@ def test_exclude_keys():
     output_file = f"/tmp/nemo-skills-tests/data/processed_compact_output.jsonl"
     docker_rm_and_mkdir(output_file)
     run_cmd(
-        module="nemo_skills.training.prepare_sft_data ",
+        cmd="python -m nemo_skills.training.prepare_sft_data ",
         cluster='test-local',
         config_dir=Path(__file__).parent / 'gpu-tests',
         log_dir='/tmp/nemo-skills-tests/test_exclude_keys',
@@ -118,7 +118,7 @@ def test_code_sft_data():
     output_file = f"/tmp/nemo-skills-tests/data/code_processed_output.jsonl"
     docker_rm_and_mkdir(output_file)
     run_cmd(
-        module="nemo_skills.training.prepare_sft_data ",
+        cmd="python -m nemo_skills.training.prepare_sft_data ",
         cluster='test-local',
         config_dir=Path(__file__).parent / 'gpu-tests',
         log_dir='/tmp/nemo-skills-tests/test_code_sft_data',
@@ -146,7 +146,7 @@ def test_openmathinstruct2():
     output_file = f"/tmp/nemo-skills-tests/data/openmathinstruct2-sft.jsonl"
     docker_rm_and_mkdir(output_file)
     run_cmd(
-        module="nemo_skills.training.prepare_sft_data ",
+        cmd="python -m nemo_skills.training.prepare_sft_data ",
         cluster='test-local',
         config_dir=Path(__file__).parent / 'gpu-tests',
         log_dir='/tmp/nemo-skills-tests/test_openmathinstruct2',


### PR DESCRIPTION
This removes complexity from `run_cmd` by adding only one option for the command to run and allowing it to be an arbitrary script.